### PR TITLE
feat(office_service): Implement OpenTelemetry for distributed tracing

### DIFF
--- a/services/office_service/tests/conftest.py
+++ b/services/office_service/tests/conftest.py
@@ -16,10 +16,9 @@ import pytest
 # Add the parent directory to sys.path to enable relative imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from app.main import app
 from core.token_manager import TokenData
 from fastapi.testclient import TestClient
-
-from app.main import app
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/services/office_service/tests/test_api_email.py
+++ b/services/office_service/tests/test_api_email.py
@@ -9,11 +9,10 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from app.main import app
 from fastapi.testclient import TestClient
 from models import Provider
 from schemas import EmailAddress, EmailMessage, SendEmailRequest
-
-from app.main import app
 
 
 @pytest.fixture

--- a/services/office_service/tests/test_error_handling.py
+++ b/services/office_service/tests/test_error_handling.py
@@ -3,6 +3,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from app.main import (
+    office_service_error_handler,
+    provider_api_error_handler,
+    rate_limit_error_handler,
+)
 from core.clients.google import GoogleAPIClient
 from core.exceptions import (
     OfficeServiceError,
@@ -12,12 +17,6 @@ from core.exceptions import (
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from models import Provider
-
-from app.main import (
-    office_service_error_handler,
-    provider_api_error_handler,
-    rate_limit_error_handler,
-)
 
 
 class TestGlobalExceptionHandlers:


### PR DESCRIPTION
This commit introduces distributed tracing to the office_service using OpenTelemetry and Google Cloud Trace.

Key changes:
- Added OpenTelemetry dependencies to `requirements.txt`.
- Updated `Dockerfile.office-service` to use `opentelemetry-instrument` for launching the application, enabling auto-instrumentation for FastAPI and HTTPX.
- Added documentation in `documentation/office-service.md` detailing:
    - IAM permissions required for Google Cloud Trace.
    - Environment variables for configuring OpenTelemetry with GCP.
    - Example `gcloud run deploy` command.
    - Instructions for local development with console trace exporting.

The implementation follows the design specified in the issue, allowing for better visibility into request flows and performance bottlenecks.

All linting checks and automated tests pass successfully.