### PR TITLE
Add OpenTelemetry to user_service

### DIFF
--- a/Dockerfile.user-service
+++ b/Dockerfile.user-service
@@ -37,4 +37,5 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8001/health || exit 1
 
 # Define the command to run the application
-CMD ["uvicorn", "services.user_management.main:app", "--host", "0.0.0.0", "--port", "8001"] 
+ENTRYPOINT ["opentelemetry-instrument"]
+CMD ["uvicorn", "services.user_management.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/services/user_management/README.md
+++ b/services/user_management/README.md
@@ -1,0 +1,48 @@
+# User Management Service - OpenTelemetry Configuration
+
+This document outlines how to configure OpenTelemetry for the User Management Service, both for deployment on Google Cloud Run and for local development.
+
+---
+
+## OpenTelemetry Configuration for Google Cloud Run
+
+### IAM Permissions
+The service account used by your Cloud Run service needs permission to write traces.
+- Navigate to the IAM page in the Google Cloud Console.
+- Find the service account your Cloud Run service uses (by default, it's `[PROJECT_NUMBER]-compute@developer.gserviceaccount.com`).
+- Grant it the "Cloud Trace Agent" role (`roles/cloudtrace.agent`).
+
+### Environment Variables
+Deploy your service with the following environment variables:
+- `OTEL_TRACES_EXPORTER=gcp_trace`
+- `OTEL_SERVICE_NAME=user-service`
+- `OTEL_PYTHON_TRACER_PROVIDER=sdk_tracer_provider` (This is required for the GCP Trace Exporter)
+
+### Deployment Command
+Example `gcloud run deploy` command:
+```bash
+gcloud run deploy user-service \
+  --image gcr.io/[PROJECT_ID]/[USER_SERVICE_IMAGE_NAME] \
+  --platform managed \
+  --region [YOUR_REGION] \
+  --allow-unauthenticated \
+  --set-env-vars="OTEL_TRACES_EXPORTER=gcp_trace" \
+  --set-env-vars="OTEL_SERVICE_NAME=user-service" \
+  --set-env-vars="OTEL_PYTHON_TRACER_PROVIDER=sdk_tracer_provider"
+```
+Replace `[PROJECT_ID]`, `[USER_SERVICE_IMAGE_NAME]`, and `[YOUR_REGION]` with your specific values. The `user-service` typically runs on port 8001, which should be configured in your `Dockerfile.user-service`.
+
+---
+
+## Local Development with OpenTelemetry
+
+For local development, you can configure OpenTelemetry to print traces directly to your console. This is useful for verifying that instrumentation is working without sending data to Google Cloud Trace.
+
+Use the following command to run your service locally with console tracing:
+```bash
+OTEL_TRACES_EXPORTER=console \
+OTEL_SERVICE_NAME=local-user-service \
+opentelemetry-instrument uvicorn services.user_management.main:app --reload --host 0.0.0.0 --port 8001
+```
+When you make a request to your local service, you will see trace data printed as JSON in your terminal.
+---


### PR DESCRIPTION
This commit introduces OpenTelemetry tracing to the user_service.

Key changes:
- Updated `Dockerfile.user-service` to use `opentelemetry-instrument` as the entrypoint, similar to other services.
- Verified that `requirements.txt` already contains the necessary OpenTelemetry dependencies.
- Added a `README.md` in `services/user_management/` with instructions for:
    - Configuring IAM permissions for Google Cloud Run.
    - Setting required environment variables (`OTEL_TRACES_EXPORTER`, `OTEL_SERVICE_NAME`, `OTEL_PYTHON_TRACER_PROVIDER`).
    - An example `gcloud run deploy` command for `user-service`.
    - Running the `user_service` locally with OpenTelemetry and console tracing.