### PR TITLE
feat: Add OpenTelemetry to chat_service Docker deployment

### DIFF
--- a/Dockerfile.chat-service
+++ b/Dockerfile.chat-service
@@ -1,23 +1,26 @@
 # Dockerfile for chat Service (Python/FastAPI)
 
 # Use an official Python runtime as a parent image
-FROM python:3.11-slim
+FROM python:3.11-slim-bullseye
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
 
 # Set work directory
-WORKDIR /app
+WORKDIR /app/chat-service
 
 # Install Python dependencies
 # First, copy only the requirements file to leverage Docker cache
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Copy the rest of the application code for the chat service
-# Assuming the chat service code is in services/chat-service/
-COPY services/chat-service/ ./services/chat-service/
+COPY services/chat_service/ /app/chat-service/
 
 # Expose the port the app runs on (e.g., 8000 for FastAPI)
 EXPOSE 8000
 
 # Define the command to run the application
-# This assumes your FastAPI app is in main.py and the app object is named "app"
+ENTRYPOINT ["opentelemetry-instrument"]
 CMD ["uvicorn", "services.chat-service.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/demos/README_chat.md
+++ b/services/demos/README_chat.md
@@ -14,3 +14,48 @@ pip install -r requirements.txt
 uvicorn services.chat_service.main:app --port 8000 --host 0.0.0.0 &
 python services/demos/chat.py
 ```
+
+## Running with Docker and OpenTelemetry
+
+This service can be containerized using Docker. The provided `Dockerfile.chat-service` is configured to run the service with OpenTelemetry instrumentation.
+
+### 1. Build the Docker Image
+
+Navigate to the root of the repository and run:
+
+```bash
+docker build -t chat-service -f Dockerfile.chat-service .
+```
+
+### 2. Run the Docker Container
+
+Once the image is built, you can run the service using:
+
+```bash
+docker run -d -p 8000:8000 --name chat_service chat-service
+```
+
+This command will:
+- Run the container in detached mode (`-d`).
+- Map port 8000 of the host to port 8000 of the container (`-p 8000:8000`).
+- Name the container `chat_service` for easier management.
+
+OpenTelemetry is automatically enabled because the Docker image's entrypoint is set to `opentelemetry-instrument`. You can configure the OpenTelemetry exporter and other settings via environment variables when running the container. For example, to send traces to a local Jaeger instance:
+
+```bash
+docker run -d -p 8000:8000 \
+  --name chat_service \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317" \
+  -e OTEL_SERVICE_NAME="chat-service" \
+  chat-service
+```
+
+Refer to the OpenTelemetry documentation for more details on configuration options.
+
+### 3. Using the Service
+
+After starting the container, the chat service will be available at `http://localhost:8000`.
+You can then run the demo script:
+```bash
+python services/demos/chat.py
+```


### PR DESCRIPTION
This commit introduces OpenTelemetry instrumentation to the Docker deployment of the `chat_service`.

Changes include:
- Updated `Dockerfile.chat-service` to:
  - Use `python:3.11-slim-bullseye` as the base image.
  - Set the entrypoint to `opentelemetry-instrument` to enable automatic tracing.
  - Align working directory and dependency installation with `Dockerfile.office-service`.
- Updated `services/demos/README_chat.md` to:
  - Include instructions for building the `chat_service` Docker image.
  - Provide commands for running the container with OpenTelemetry.
  - Offer an example of configuring OpenTelemetry exporters via environment variables.

These changes mirror the existing OpenTelemetry setup in the `office_service`, providing consistent observability across services.