### PR TITLE
Fix: Update condition for uploading coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Upload coverage reports
       uses: codecov/codecov-action@v3
-      if: matrix.python-version == '3.11'
+      if: matrix.python-version == '3.12'
       with:
         file: ./coverage.xml
         fail_ci_if_error: false


### PR DESCRIPTION
The condition for uploading coverage reports in the CI workflow was incorrectly set to Python 3.11, while the workflow uses Python 3.12. This commit updates the condition to Python 3.12, ensuring that coverage reports are uploaded as expected.