### PR TITLE
Refactor: Update Pydantic validators to V2 style in webhook schemas

### DIFF
--- a/services/user_management/schemas/webhook.py
+++ b/services/user_management/schemas/webhook.py
@@ -8,7 +8,7 @@ from external services like Clerk.
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class ClerkWebhookEventData(BaseModel):
@@ -26,7 +26,7 @@ class ClerkWebhookEventData(BaseModel):
         None, description="Update timestamp in milliseconds"
     )
 
-    @validator("email_addresses", pre=True)
+    @field_validator("email_addresses", mode='before')
     def extract_primary_email(cls, v) -> Optional[str]:
         """Extract primary email from email addresses array."""
         if v and isinstance(v, list) and len(v) > 0:
@@ -50,7 +50,7 @@ class ClerkWebhookEvent(BaseModel):
     object: str = Field(..., description="Object type (e.g., event)")
     timestamp: Optional[int] = Field(None, description="Event timestamp")
 
-    @validator("type")
+    @field_validator("type")
     def validate_event_type(cls, v):
         """Validate that we support this event type."""
         supported_events = ["user.created", "user.updated", "user.deleted"]

--- a/services/user_management/schemas/webhook.py
+++ b/services/user_management/schemas/webhook.py
@@ -26,7 +26,7 @@ class ClerkWebhookEventData(BaseModel):
         None, description="Update timestamp in milliseconds"
     )
 
-    @field_validator("email_addresses", mode='before')
+    @field_validator("email_addresses", mode="before")
     def extract_primary_email(cls, v) -> Optional[str]:
         """Extract primary email from email addresses array."""
         if v and isinstance(v, list) and len(v) > 0:


### PR DESCRIPTION
I've converted @validator to @field_validator in services/user_management/schemas/webhook.py as per Pydantic V2 migration guidelines.

- I replaced `@validator("email_addresses", pre=True)` with `@field_validator("email_addresses", mode='before')`.
- I replaced `@validator("type")` with `@field_validator("type")`.
