### PR TITLE
Refactor: Standardize ready endpoint for Office Service

### DIFF
--- a/services/office_service/api/health.py
+++ b/services/office_service/api/health.py
@@ -313,16 +313,3 @@ async def quick_health_check():
         "version": settings.APP_VERSION,
         "timestamp": datetime.utcnow().isoformat(),
     }
-
-
-@router.get("/ready")
-async def ready_check():
-    """
-    Simple readiness check.
-    """
-    return {
-        "status": "ok",
-        "service": settings.APP_NAME,
-        "version": settings.APP_VERSION,
-        "timestamp": datetime.utcnow().isoformat(),
-    }

--- a/services/office_service/app/main.py
+++ b/services/office_service/app/main.py
@@ -15,6 +15,7 @@ from core.exceptions import (
     ValidationError,
 )
 from core.logging_config import setup_logging
+from datetime import datetime
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from schemas import ApiError
@@ -303,3 +304,16 @@ async def read_root():
     """Hello World root endpoint"""
     logger.info("Root endpoint accessed")
     return {"message": "Hello World", "service": "Office Service"}
+
+
+@app.get("/ready")
+async def ready_check():
+    """
+    Simple readiness check.
+    """
+    return {
+        "status": "ok",
+        "service": settings.APP_NAME,
+        "version": settings.APP_VERSION,
+        "timestamp": datetime.utcnow().isoformat(),
+    }


### PR DESCRIPTION
Makes the ready endpoint for the Office Service consistent with other services by changing it from `/health/ready` to `/ready`.

- Moved `ready_check` function from `office_service/api/health.py` to `office_service/app/main.py`.
- Updated the route decorator to `@app.get("/ready")`.
- Ensured necessary imports are in place in `main.py`.