### PR TITLE
Configure VS Code multi-root workspace

### DIFF
--- a/briefly.code-workspace
+++ b/briefly.code-workspace
@@ -1,0 +1,8 @@
+{
+  "folders": [
+    { "path": "services/chat_service" },
+    { "path": "services/office_service" },
+    { "path": "services/user_management" },
+    { "path": "services/vector-db" }
+  ]
+}

--- a/services/chat_service/.vscode/settings.json
+++ b/services/chat_service/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.defaultInterpreterPath": "venv/bin/python"
+}

--- a/services/office_service/.vscode/settings.json
+++ b/services/office_service/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.defaultInterpreterPath": "venv/bin/python"
+}

--- a/services/user_management/.vscode/settings.json
+++ b/services/user_management/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.defaultInterpreterPath": "venv/bin/python"
+}

--- a/services/vector-db/.vscode/settings.json
+++ b/services/vector-db/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.defaultInterpreterPath": "venv/bin/python"
+}


### PR DESCRIPTION
This change introduces a multi-root workspace configuration for VS Code, improving the development experience for this monorepo.

Key changes:
- Added `briefly.code-workspace` to define the service folders.
- Added service-specific `.vscode/settings.json` files to configure the Python interpreter for each service (`chat_service`, `office_service`, `user_management`, `vector-db`).

This setup allows VS Code to correctly identify and use the virtual environment for each service, providing accurate linting, debugging, and other language-specific features.