### PR TITLE
Use a root virtual environment for development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,9 @@ npm run build        # Production build
 
 ### Backend Services
 ```bash
+./setup-dev.sh       # Set up unified development environment
+source venv/bin/activate
 cd services/{service}/
-python -m venv venv && source venv/bin/activate
-pip install -r ../../requirements.txt
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,29 +36,27 @@ The Office Service is a FastAPI-based microservice that provides unified access 
    cd services/office_service
    ```
 
-2. **Create and activate virtual environment:**
+2. **Set up unified development environment:**
    ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
+   ./setup-dev.sh
    ```
+   This script will:
+   - Create a unified virtual environment for all services
+   - Install all dependencies from all services
+   - Install shared packages in editable mode
 
-3. **Install dependencies:**
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-4. **Set up environment variables:**
+3. **Set up environment variables:**
    ```bash
    cp .env.example .env
    # Edit .env with your configuration
    ```
 
-5. **Run database migrations:**
+4. **Run database migrations:**
    ```bash
    alembic upgrade head
    ```
 
-6. **Start the service:**
+5. **Start the service:**
    ```bash
    uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
    ```
@@ -163,7 +161,7 @@ tox -p auto             # Full test matrix
         ```bash
         # Office Service Testing:
         cd services/office_service
-        source venv/bin/activate  # Activate virtual environment
+        # Virtual environment is already activated by setup-dev.sh
         pytest                    # Run all tests
         pytest tests/test_integration.py  # Run integration tests only
         

--- a/briefly.code-workspace
+++ b/briefly.code-workspace
@@ -1,8 +1,5 @@
 {
   "folders": [
-    { "path": "." },
-    { "path": "services/chat_service" },
-    { "path": "services/office_service" },
-    { "path": "services/user_management" }
+    { "path": "." }
   ]
 }

--- a/documentation/python-monorepo-info.md
+++ b/documentation/python-monorepo-info.md
@@ -69,29 +69,24 @@ from vector_db.indexing_service import IndexingService
 If you need to install manually for a specific service:
 
 ```bash
-cd services/{service-name}
-source venv/bin/activate
-pip install -e ../common
-pip install -e ../vector-db
-deactivate
+# The unified setup script handles this automatically
+./setup-dev.sh
 ```
 
-Example for office_service:
+For manual installation (if needed):
 ```bash
-cd services/office_service
-source venv/bin/activate
+cd services/{service-name}
+source ../../venv/bin/activate  # Use unified venv
 pip install -e ../common
 pip install -e ../vector-db
-deactivate
 ```
 
 ## Verification
 
 To verify the setup works:
 
-1. Activate any service's virtual environment:
+1. Activate the unified virtual environment:
    ```bash
-   cd services/office_service
    source venv/bin/activate
    ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ llama-index>=0.12.0,<0.13.0
 llama-index-embeddings-openai>=0.3.0,<0.4.0
 llama-index-llms-litellm>=0.3.0,<0.6.0
 sqlmodel>=0.0.21
-pinecone-client
+pinecone
 psycopg2-binary
 pydantic-settings
 pydantic>=2.0,<2.9.0

--- a/services/chat_service/.vscode/settings.json
+++ b/services/chat_service/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "python.defaultInterpreterPath": "venv/bin/python",
-  "python.analysis.extraPaths": ["../common", "../vector-db"]
-}

--- a/services/chat_service/start.sh
+++ b/services/chat_service/start.sh
@@ -5,9 +5,9 @@
 
 cd "$(dirname "$0")/../.."
 
-# Activate the virtual environment if it exists
-if [ -d "services/user_management/venv" ]; then
-    source services/user_management/venv/bin/activate
+# Activate the unified virtual environment if it exists
+if [ -d "venv" ]; then
+    source venv/bin/activate
 fi
 
 # Run uvicorn with proper package path

--- a/services/demos/README_chat.md
+++ b/services/demos/README_chat.md
@@ -19,9 +19,9 @@ cd services/chat_service
 
 Client:
 ```bash
-cd services/chat_service
+# From repository root with unified environment
 source venv/bin/activate
-python ../demos/chat.py
+python services/demos/chat.py
 ```
 
 ## Troubleshooting

--- a/services/demos/README_office.md
+++ b/services/demos/README_office.md
@@ -67,10 +67,9 @@ You can set one or both tokens depending on which services you want to test.
 ### 4. Run the Demo
 
 ```bash
-# From the repository root
-cd services/chat_service
+# From the repository root with unified environment
 source venv/bin/activate
-python ../demos/office.py user@example.com
+python services/demos/office.py user@example.com
 ```
 
 The email address is used as a user identifier for the API calls and logging.

--- a/services/demos/README_office_full.md
+++ b/services/demos/README_office_full.md
@@ -49,9 +49,9 @@ cd services/office_service
 ### Step 2: Run the Full Demo
 
 ```bash
-cd services/chat_service
+# From repository root with unified environment
 source venv/bin/activate
-python ../demos/office_full.py user@example.com
+python services/demos/office_full.py user@example.com
 ```
 
 ## Demo Flow

--- a/services/office_service/.vscode/settings.json
+++ b/services/office_service/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "python.defaultInterpreterPath": "venv/bin/python",
-  "python.analysis.extraPaths": ["../common", "../vector-db"]
-}

--- a/services/office_service/start.sh
+++ b/services/office_service/start.sh
@@ -5,9 +5,9 @@
 
 cd "$(dirname "$0")/../.."
 
-# Activate the virtual environment if it exists
-if [ -d "services/user_management/venv" ]; then
-    source services/user_management/venv/bin/activate
+# Activate the unified virtual environment if it exists
+if [ -d "venv" ]; then
+    source venv/bin/activate
 fi
 
 # Run uvicorn with proper package path

--- a/services/user_management/.vscode/settings.json
+++ b/services/user_management/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "python.defaultInterpreterPath": "venv/bin/python",
-  "python.analysis.extraPaths": ["../common", "../vector-db"]
-}

--- a/services/user_management/start.sh
+++ b/services/user_management/start.sh
@@ -5,9 +5,9 @@
 
 cd "$(dirname "$0")/../.."
 
-# Activate the virtual environment if it exists
-if [ -d "services/user_management/venv" ]; then
-    source services/user_management/venv/bin/activate
+# Activate the unified virtual environment if it exists
+if [ -d "venv" ]; then
+    source venv/bin/activate
 fi
 
 # Run uvicorn with proper package path

--- a/tasks/tasks-office-service.md
+++ b/tasks/tasks-office-service.md
@@ -41,7 +41,8 @@ When working with task lists, the AI must:
 General instructions for working in Python in this repo:
 
 Setup:
-* Activate the virtual environment: `source venv/bin/activate`
+* Set up the unified development environment: `./setup-dev.sh`
+* The virtual environment will be automatically activated
 * Run all Python commands from the repository root.
 
 Before committing:

--- a/tasks/tasks-user-service.md
+++ b/tasks/tasks-user-service.md
@@ -21,7 +21,8 @@
 ## General instructions for working in Python in this repo
 
 ### Setup
-* Activate the virtual environment: `source venv/bin/activate`
+* Set up the unified development environment: `./setup-dev.sh`
+* The virtual environment will be automatically activated
 * Run all Python commands from the repository root.
 
 ### Before committing


### PR DESCRIPTION
- Update setup-dev.sh to dynamically discover services and merge requirements
- Replace all legacy service-specific venv references with unified root venv  
- Update service start scripts to use ../../venv instead of local venv
- Fix documentation across README, tasks, demos, and monorepo guides
- Simplify development workflow with single environment activation