### PR TITLE
Refactor LLMManager to lazy-loaded singleton

### DIFF
--- a/services/chat/chat_agent.py
+++ b/services/chat/chat_agent.py
@@ -34,7 +34,7 @@ from llama_index.core.vector_stores import SimpleVectorStore
 from llama_index.embeddings.openai import OpenAIEmbedding
 
 from services.chat import history_manager
-from services.chat.llm_manager import FakeLLM, llm_manager
+from services.chat.llm_manager import FakeLLM, get_llm_manager
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ class ChatAgent:
         self.llm_kwargs = llm_kwargs or {}
 
         # Initialize LLM instance
-        self.llm = llm_manager.get_llm(
+        self.llm = get_llm_manager().get_llm(
             model=llm_model, provider=llm_provider, **self.llm_kwargs
         )
 

--- a/services/chat/llm_manager.py
+++ b/services/chat/llm_manager.py
@@ -342,6 +342,7 @@ class _LLMManager:
 # Global instance
 _llm_manager_instance: Optional[_LLMManager] = None
 
+
 def get_llm_manager() -> _LLMManager:
     """
     Returns a singleton instance of the _LLMManager.

--- a/services/chat/llm_manager.py
+++ b/services/chat/llm_manager.py
@@ -258,7 +258,7 @@ class FakeLLM(FunctionCallingLLM):
         yield await self.acomplete(prompt, **kwargs)
 
 
-class LLMManager:
+class _LLMManager:
     """
     Manages LLM instances with LiteLLM, providing a unified interface for different models.
     """
@@ -269,7 +269,7 @@ class LLMManager:
 
     def __new__(cls):
         if cls._instance is None:
-            cls._instance = super(LLMManager, cls).__new__(cls)
+            cls._instance = super(_LLMManager, cls).__new__(cls)
             cls._default_provider = os.getenv("LLM_PROVIDER", "openai")
             cls._default_model = os.getenv("LLM_MODEL", "gpt-4.1-nano")
         return cls._instance
@@ -340,4 +340,14 @@ class LLMManager:
 
 
 # Global instance
-llm_manager = LLMManager()
+_llm_manager_instance: Optional[_LLMManager] = None
+
+def get_llm_manager() -> _LLMManager:
+    """
+    Returns a singleton instance of the _LLMManager.
+    Initializes the instance upon first call.
+    """
+    global _llm_manager_instance
+    if _llm_manager_instance is None:
+        _llm_manager_instance = _LLMManager()
+    return _llm_manager_instance

--- a/services/chat/tests/test_chat_agent.py
+++ b/services/chat/tests/test_chat_agent.py
@@ -259,13 +259,15 @@ async def test_chat_with_agent(
 async def test_graceful_fallback_on_memory_errors():
     """Test that the agent gracefully handles memory block creation errors."""
     with (
-        patch("services.chat.chat_agent.llm_manager") as mock_llm_manager,
+        patch("services.chat.chat_agent.get_llm_manager") as mock_get_llm_manager_func,
         patch("services.chat.chat_agent.history_manager") as mock_history_manager,
         patch("services.chat.chat_agent.VectorMemoryBlock") as mock_vector_block,
     ):
 
         mock_llm = MagicMock()
-        mock_llm_manager.return_value = mock_llm
+        mock_llm_manager_instance = MagicMock()
+        mock_llm_manager_instance.get_llm.return_value = mock_llm
+        mock_get_llm_manager_func.return_value = mock_llm_manager_instance
         mock_history_manager.get_conversation_history = AsyncMock(return_value=[])
 
         # Make VectorMemoryBlock raise an exception
@@ -316,7 +318,7 @@ async def test_memory_blocks_priority_order():
 async def test_agent_with_tools():
     """Test agent creation with custom tools."""
     with (
-        patch("services.chat.chat_agent.llm_manager") as mock_llm_manager,
+        patch("services.chat.chat_agent.get_llm_manager") as mock_get_llm_manager_func,
         patch("services.chat.chat_agent.history_manager") as mock_history_manager,
         patch("services.chat.chat_agent.FunctionCallingAgent") as mock_agent_class,
     ):
@@ -325,7 +327,9 @@ async def test_agent_with_tools():
         mock_llm = MagicMock()
         mock_llm.metadata = MagicMock()
         mock_llm.metadata.is_function_calling_model = True
-        mock_llm_manager.return_value = mock_llm
+        mock_llm_manager_instance = MagicMock()
+        mock_llm_manager_instance.get_llm.return_value = mock_llm
+        mock_get_llm_manager_func.return_value = mock_llm_manager_instance
         mock_history_manager.get_conversation_history = AsyncMock(return_value=[])
 
         # Mock the agent creation


### PR DESCRIPTION
I replaced the global LLMManager instance in services/chat/llm_manager.py with a lazy-loaded singleton pattern.

- I renamed LLMManager to _LLMManager.
- I introduced a get_llm_manager() function to access the singleton instance.
- I updated services/chat/chat_agent.py to use get_llm_manager().
- I adjusted mocks in services/chat/tests/test_chat_agent.py to align with the new access pattern.

This change avoids module-load initialization, improving testability.