### PR TITLE
Improve LLM tool selection for calendar draft editing

### DIFF
--- a/services/chat/agents/draft_agent.py
+++ b/services/chat/agents/draft_agent.py
@@ -79,8 +79,11 @@ class DraftAgent(FunctionAgent):
                 "compose, draft, or modify emails and calendar items."
             ),
             system_prompt=(
-                "You are the DraftAgent, specialized in creating and managing drafts. "
-                "You can create draft emails, calendar events, and calendar changes. "
+                "You are the DraftAgent, specialized in creating and managing drafts in the current conversation. "
+                "You can create draft emails and calendar events. "
+                "IMPORTANT: When users want to modify or update existing calendar event drafts (like changing time, location, attendees), "
+                "always use the 'create_draft_calendar_event' tool - it will automatically update the existing draft with new values. "
+                "Do NOT create separate 'calendar change' drafts for updates. "
                 "When creating drafts, be thorough and ask for all necessary details. "
                 "Use the available tools to create, update, or delete drafts as needed. "
                 "Record draft information for other agents to reference. "
@@ -147,14 +150,14 @@ class DraftAgent(FunctionAgent):
             fn=create_email_draft,
             name="create_draft_email",
             description=(
-                "Create or update a draft email. Provide to, cc, bcc, subject, and body. "
-                "The thread_id is automatically handled by the agent."
+                "Create or update a draft email in the current conversation. Provide to, cc, bcc, subject, and body. "
+                "The conversation context is automatically handled by the agent."
             ),
         )
         tools.append(create_email_draft_tool)
 
         def delete_email_draft(ctx: Context) -> str:
-            """Delete the draft email for this thread."""
+            """Delete the draft email for this conversation."""
             logger.info(f"🗑️ DraftAgent: Deleting email draft for thread {thread_id}")
             result = delete_draft_email(thread_id)
             return str(result)
@@ -162,7 +165,7 @@ class DraftAgent(FunctionAgent):
         delete_email_draft_tool = FunctionTool.from_defaults(
             fn=delete_email_draft,
             name="delete_draft_email",
-            description="Delete the draft email for the current thread.",
+            description="Delete the draft email in the current conversation.",
         )
         tools.append(delete_email_draft_tool)
 
@@ -215,14 +218,14 @@ class DraftAgent(FunctionAgent):
             fn=create_calendar_event_draft,
             name="create_draft_calendar_event",
             description=(
-                "Create or update a draft calendar event. Provide title, start_time, end_time, "
-                "attendees, location, and description. The thread_id is automatically handled by the agent."
+                "Create or update a draft calendar event in the current conversation. Use this for both creating new calendar events AND updating existing calendar event drafts (e.g., changing time, location, attendees). "
+                "Provide title, start_time, end_time, attendees, location, and description. The conversation context is automatically handled by the agent."
             ),
         )
         tools.append(create_calendar_event_draft_tool)
 
         def delete_calendar_event_draft(ctx: Context) -> str:
-            """Delete the draft calendar event for this thread."""
+            """Delete the draft calendar event for this conversation."""
             logger.info(
                 f"🗑️ DraftAgent: Deleting calendar event draft for thread {thread_id}"
             )
@@ -232,7 +235,7 @@ class DraftAgent(FunctionAgent):
         delete_calendar_event_draft_tool = FunctionTool.from_defaults(
             fn=delete_calendar_event_draft,
             name="delete_draft_calendar_event",
-            description="Delete the draft calendar event for the current thread.",
+            description="Delete the draft calendar event in the current conversation.",
         )
         tools.append(delete_calendar_event_draft_tool)
 

--- a/services/chat/agents/llm_tools.py
+++ b/services/chat/agents/llm_tools.py
@@ -359,32 +359,27 @@ def make_tools() -> Dict[str, FunctionTool]:
     create_draft_email_tool = FunctionTool.from_defaults(
         fn=create_draft_email,
         name="create_draft_email",
-        description="Create or update draft email for a thread.",
+        description="Create or update draft email in the current conversation.",
     )
     delete_draft_email_tool = FunctionTool.from_defaults(
         fn=delete_draft_email,
         name="delete_draft_email",
-        description="Delete draft email for a thread.",
+        description="Delete draft email in the current conversation.",
     )
     create_draft_calendar_event_tool = FunctionTool.from_defaults(
         fn=create_draft_calendar_event,
         name="create_draft_calendar_event",
-        description="Create or update draft calendar event for a thread.",
+        description="Create or update a draft calendar event in the current conversation. Use this tool for both creating new calendar event drafts AND modifying existing calendar event drafts (e.g., changing time, location, attendees, etc.). If a draft already exists, it will be updated with the new values.",
     )
     delete_draft_calendar_event_tool = FunctionTool.from_defaults(
         fn=delete_draft_calendar_event,
         name="delete_draft_calendar_event",
-        description="Delete draft calendar event for a thread.",
+        description="Delete draft calendar event in the current conversation.",
     )
     create_draft_calendar_change_tool = FunctionTool.from_defaults(
         fn=create_draft_calendar_change,
         name="create_draft_calendar_change",
-        description="Create or update draft calendar change for a thread.",
-    )
-    delete_draft_calendar_change_tool = FunctionTool.from_defaults(
-        fn=delete_draft_calendar_change,
-        name="delete_draft_calendar_change",
-        description="Delete draft calendar change for a thread.",
+        description="[DEPRECATED] Create or update draft calendar change in the current conversation. Use create_draft_calendar_event instead for all calendar draft operations.",
     )
 
     return {
@@ -397,7 +392,6 @@ def make_tools() -> Dict[str, FunctionTool]:
         "create_draft_calendar_event": create_draft_calendar_event_tool,
         "delete_draft_calendar_event": delete_draft_calendar_event_tool,
         "create_draft_calendar_change": create_draft_calendar_change_tool,
-        "delete_draft_calendar_change": delete_draft_calendar_change_tool,
     }
 
 

--- a/services/chat/tests/test_calendar_draft_update.py
+++ b/services/chat/tests/test_calendar_draft_update.py
@@ -6,7 +6,6 @@ using the create_draft_calendar_event function, which should be used
 for both creating and updating drafts.
 """
 
-
 from services.chat.agents.llm_tools import (
     _draft_storage,
     create_draft_calendar_event,

--- a/services/chat/tests/test_calendar_draft_update.py
+++ b/services/chat/tests/test_calendar_draft_update.py
@@ -1,0 +1,125 @@
+"""
+Test calendar event draft update functionality.
+
+This test verifies that calendar event drafts can be properly updated
+using the create_draft_calendar_event function, which should be used
+for both creating and updating drafts.
+"""
+
+
+from services.chat.agents.llm_tools import (
+    _draft_storage,
+    create_draft_calendar_event,
+)
+
+
+class TestCalendarDraftUpdate:
+    """Test calendar event draft update workflows."""
+
+    def setup_method(self):
+        """Clear draft storage before each test."""
+        _draft_storage.clear()
+
+    def teardown_method(self):
+        """Clear draft storage after each test."""
+        _draft_storage.clear()
+
+    def test_create_then_update_calendar_event_draft(self):
+        """Test creating a calendar event draft and then updating its time."""
+        thread_id = "1150"
+
+        # Step 1: Create initial draft
+        result1 = create_draft_calendar_event(
+            thread_id=thread_id,
+            title="Breakfast with Laura",
+            start_time="2023-10-05T08:00:00",
+            end_time="2023-10-05T09:00:00",
+            attendees="laura@gmail.com",
+            location="Pete's coffee",
+            description="Breakfast with Laura at Pete's coffee.",
+        )
+
+        assert result1["success"] is True
+        assert result1["draft"]["title"] == "Breakfast with Laura"
+        assert result1["draft"]["start_time"] == "2023-10-05T08:00:00"
+
+        # Verify draft is stored
+        draft_key = f"{thread_id}_calendar_event"
+        assert draft_key in _draft_storage
+        assert _draft_storage[draft_key]["start_time"] == "2023-10-05T08:00:00"
+
+        # Step 2: Update the start time to 9am (this should update the existing draft)
+        result2 = create_draft_calendar_event(
+            thread_id=thread_id, start_time="2023-10-05T09:00:00"  # Change to 9am
+        )
+
+        assert result2["success"] is True
+        assert (
+            result2["draft"]["title"] == "Breakfast with Laura"
+        )  # Should keep existing title
+        assert (
+            result2["draft"]["start_time"] == "2023-10-05T09:00:00"
+        )  # Should update time
+        assert (
+            result2["draft"]["attendees"] == "laura@gmail.com"
+        )  # Should keep existing attendees
+        assert (
+            result2["draft"]["location"] == "Pete's coffee"
+        )  # Should keep existing location
+
+        # Verify only ONE draft exists (the updated one)
+        assert len([k for k in _draft_storage.keys() if k.startswith(thread_id)]) == 1
+        assert _draft_storage[draft_key]["start_time"] == "2023-10-05T09:00:00"
+
+        # Step 3: Update multiple fields at once
+        result3 = create_draft_calendar_event(
+            thread_id=thread_id,
+            start_time="2023-10-05T10:00:00",  # Change to 10am
+            location="Starbucks on Main St",  # Change location
+        )
+
+        assert result3["success"] is True
+        assert result3["draft"]["start_time"] == "2023-10-05T10:00:00"
+        assert result3["draft"]["location"] == "Starbucks on Main St"
+        assert (
+            result3["draft"]["title"] == "Breakfast with Laura"
+        )  # Should keep existing title
+        assert (
+            result3["draft"]["attendees"] == "laura@gmail.com"
+        )  # Should keep existing attendees
+
+        # Still only one draft
+        assert len([k for k in _draft_storage.keys() if k.startswith(thread_id)]) == 1
+
+    def test_partial_update_preserves_existing_fields(self):
+        """Test that partial updates preserve existing field values."""
+        thread_id = "test_partial"
+
+        # Create full draft
+        create_draft_calendar_event(
+            thread_id=thread_id,
+            title="Team Meeting",
+            start_time="2023-10-05T14:00:00",
+            end_time="2023-10-05T15:00:00",
+            attendees="team@company.com",
+            location="Conference Room A",
+            description="Weekly team sync",
+        )
+
+        # Update only the time
+        result = create_draft_calendar_event(
+            thread_id=thread_id,
+            start_time="2023-10-05T15:00:00",  # Only change start time
+            end_time="2023-10-05T16:00:00",  # Only change end time
+        )
+
+        # All other fields should be preserved
+        draft = result["draft"]
+        assert draft["title"] == "Team Meeting"
+        assert draft["attendees"] == "team@company.com"
+        assert draft["location"] == "Conference Room A"
+        assert draft["description"] == "Weekly team sync"
+
+        # New times should be applied
+        assert draft["start_time"] == "2023-10-05T15:00:00"
+        assert draft["end_time"] == "2023-10-05T16:00:00"


### PR DESCRIPTION
 - use natural language 'current conversation' instead of technical 'thread', emphasize create_draft_calendar_event for both creating and updating drafts