### PR TITLE
Refactor: Make event_id required for create_draft_calendar_change

### DIFF
--- a/services/chat/agents/draft_agent.py
+++ b/services/chat/agents/draft_agent.py
@@ -242,7 +242,7 @@ class DraftAgent(FunctionAgent):
         # Calendar change drafting tools
         def create_calendar_change_draft(
             ctx: Context,
-            event_id: Optional[str] = None,
+            event_id: str,
             change_type: Optional[str] = None,
             new_title: Optional[str] = None,
             new_start_time: Optional[str] = None,
@@ -253,7 +253,7 @@ class DraftAgent(FunctionAgent):
         ) -> str:
             """Create or update a draft calendar change using the agent's thread_id."""
             logger.info(
-                f"📅 DraftAgent: Creating calendar change draft - Event: {event_id}, Type: {change_type}, Thread: {thread_id}"
+                f"📅 DraftAgent: Creating calendar change draft - Event ID: {event_id}, Type: {change_type}, Thread: {thread_id}"
             )
 
             result = create_draft_calendar_change(
@@ -288,7 +288,7 @@ class DraftAgent(FunctionAgent):
             fn=create_calendar_change_draft,
             name="create_draft_calendar_change",
             description=(
-                "Create or update a draft calendar change. Provide event_id, change_type, and any "
+                "Create or update a draft calendar change. Provide the required event_id, change_type, and any "
                 "new values to change. The thread_id is automatically handled by the agent."
             ),
         )

--- a/services/chat/agents/llm_tools.py
+++ b/services/chat/agents/llm_tools.py
@@ -273,7 +273,7 @@ def delete_draft_calendar_event(thread_id: str) -> Dict[str, Any]:
 
 def create_draft_calendar_change(
     thread_id: str,
-    event_id: Optional[str] = None,
+    event_id: str,
     change_type: Optional[str] = None,
     new_title: Optional[str] = None,
     new_start_time: Optional[str] = None,


### PR DESCRIPTION
I made event_id a required parameter in the following functions:
- services.chat.agents.draft_agent.create_calendar_change_draft
- services.chat.agents.llm_tools.create_draft_calendar_change

This change enforces that an event_id must be provided when you attempt to draft a change to a calendar event.

Note: The functions for creating a draft calendar change are marked as [DEPRECATED] in the codebase. The recommended approach for all calendar draft operations (creation and updates) is to use the functionality for creating a draft calendar event.

Existing tests for calendar draft functionality continue to pass, ensuring no regressions were introduced by this change.