### PR TITLE
Change ci to not parallelize tox, which spams log with spinner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         pip install tox tox-gh-actions
 
     - name: Run tox (format, lint)
-      run: tox -e format,lint -p auto
+      run: tox -e format,lint -p auto --parallel-live
 
   typecheck:
     name: Python Type Checking
@@ -69,7 +69,7 @@ jobs:
         pip install tox tox-gh-actions
 
     - name: Run tox (typecheck)
-      run: tox -e typecheck -p auto
+      run: tox -e typecheck
 
   test:
     name: Python Tests
@@ -101,7 +101,7 @@ jobs:
         pip install tox tox-gh-actions
 
     - name: Run tox (test)
-      run: tox -e test -p auto
+      run: tox -e test
 
   coverage:
     name: Python Coverage
@@ -133,7 +133,7 @@ jobs:
         pip install tox tox-gh-actions
 
     - name: Run tox (coverage)
-      run: tox -e cov -p auto
+      run: tox -e coverage
 
     - name: Upload coverage reports
       uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         pip install tox tox-gh-actions
 
     - name: Run tox (coverage)
-      run: tox -e coverage
+      run: tox -e cov
 
     - name: Upload coverage reports
       uses: codecov/codecov-action@v3

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ deps = pytest
        -r{toxinidir}/services/office/requirements.txt
 allowlist_externals = bash
 commands =
-    python -m pytest services/ -n auto -v --tb=short
+    python -m pytest services/ -n auto -q --tb=short
 
 [testenv:test-cov]
 deps = pytest
@@ -81,9 +81,9 @@ deps = pytest
 allowlist_externals = bash
 commands =
     # Run coverage tests from each service directory and combine results
-    bash -c "cd services/user && python -m pytest tests/ --cov=. --cov-report=xml:../../coverage-user-management.xml --cov-report=term-missing"
-    bash -c "cd services/chat && python -m pytest tests/ --cov=. --cov-report=xml:../../coverage-chat-service.xml --cov-report=term-missing"
-    bash -c "cd services/office && python -m pytest tests/ --cov=. --cov-report=xml:../../coverage-office-service.xml --cov-report=term-missing"
+    bash -c "cd services/user && python -m pytest tests/ --cov=. --cov-report=xml:../../coverage-user-management.xml --cov-report=term-missing -x -q"
+    bash -c "cd services/chat && python -m pytest tests/ --cov=. --cov-report=xml:../../coverage-chat-service.xml --cov-report=term-missing -x -q"
+    bash -c "cd services/office && python -m pytest tests/ --cov=. --cov-report=xml:../../coverage-office-service.xml --cov-report=term-missing -x -q"
 
 [testenv:test-fast]
 deps = pytest
@@ -96,9 +96,9 @@ deps = pytest
 allowlist_externals = bash
 commands =
     # Run fast tests from each service directory (stop on first failure)
-    bash -c "cd services/user && python -m pytest tests/ -x -v"
-    bash -c "cd services/chat && python -m pytest tests/ -x -v"
-    bash -c "cd services/office && python -m pytest tests/ -x -v"
+    bash -c "cd services/user && python -m pytest tests/ -x -q"
+    bash -c "cd services/chat && python -m pytest tests/ -x -q"
+    bash -c "cd services/office && python -m pytest tests/ -x -q"
 
 [testenv:py312]
 deps = {[testenv:test]deps}


### PR DESCRIPTION
to remove 1000 lines of spinner progress in GHA logs