### PR TITLE
Fix various deprecation warnings and update code

### DIFF
--- a/services/chat/settings.py
+++ b/services/chat/settings.py
@@ -6,7 +6,7 @@ Uses Pydantic Settings to manage environment variables and configuration.
 
 from typing import Optional
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, ConfigDict
 from pydantic_settings import BaseSettings
 
 
@@ -66,11 +66,12 @@ class Settings(BaseSettings):
     log_level: str = Field(default="INFO", description="Logging level")
     log_format: str = Field(default="json", description="Log format (json or text)")
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-        case_sensitive = False
-        extra = "ignore"
+    model_config = ConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
 
 
 # Global settings instance

--- a/services/chat/settings.py
+++ b/services/chat/settings.py
@@ -6,11 +6,8 @@ Uses Pydantic Settings to manage environment variables and configuration.
 
 from typing import Optional
 
-from pydantic import AliasChoices, Field  # Removed ConfigDict
-from pydantic_settings import (  # Added SettingsConfigDict
-    BaseSettings,
-    SettingsConfigDict,
-)
+from pydantic import AliasChoices, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):

--- a/services/chat/settings.py
+++ b/services/chat/settings.py
@@ -6,8 +6,8 @@ Uses Pydantic Settings to manage environment variables and configuration.
 
 from typing import Optional
 
-from pydantic import AliasChoices, Field, ConfigDict
-from pydantic_settings import BaseSettings
+from pydantic import AliasChoices, Field # Removed ConfigDict
+from pydantic_settings import BaseSettings, SettingsConfigDict # Added SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -66,7 +66,7 @@ class Settings(BaseSettings):
     log_level: str = Field(default="INFO", description="Logging level")
     log_format: str = Field(default="json", description="Log format (json or text)")
 
-    model_config = ConfigDict(
+    model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,

--- a/services/chat/settings.py
+++ b/services/chat/settings.py
@@ -6,8 +6,11 @@ Uses Pydantic Settings to manage environment variables and configuration.
 
 from typing import Optional
 
-from pydantic import AliasChoices, Field # Removed ConfigDict
-from pydantic_settings import BaseSettings, SettingsConfigDict # Added SettingsConfigDict
+from pydantic import AliasChoices, Field  # Removed ConfigDict
+from pydantic_settings import (  # Added SettingsConfigDict
+    BaseSettings,
+    SettingsConfigDict,
+)
 
 
 class Settings(BaseSettings):

--- a/services/chat/tests/test_history_manager.py
+++ b/services/chat/tests/test_history_manager.py
@@ -14,7 +14,8 @@ and cleanup operations.
 """
 
 import pytest
-import pytest_asyncio # Import pytest_asyncio
+import pytest_asyncio  # Import pytest_asyncio
+
 import services.chat.history_manager as hm
 
 
@@ -26,6 +27,7 @@ async def setup_database():
     # yield # if we needed teardown per test
     # For a simple setup, we might not need specific per-test teardown if test.db is ephemeral
     # or if tests are okay with data persisting between them (not ideal but simpler for now)
+
 
 @pytest.mark.asyncio
 async def test_create_and_list_threads():

--- a/services/chat/tests/test_history_manager.py
+++ b/services/chat/tests/test_history_manager.py
@@ -14,9 +14,18 @@ and cleanup operations.
 """
 
 import pytest
-
+import pytest_asyncio # Import pytest_asyncio
 import services.chat.history_manager as hm
 
+
+@pytest_asyncio.fixture(autouse=True, scope="function")
+async def setup_database():
+    """Initialize the database and create tables before each test."""
+    # Ensure DB_URL_CHAT is set for the test environment, already done by os.environ
+    await hm.init_db()
+    # yield # if we needed teardown per test
+    # For a simple setup, we might not need specific per-test teardown if test.db is ephemeral
+    # or if tests are okay with data persisting between them (not ideal but simpler for now)
 
 @pytest.mark.asyncio
 async def test_create_and_list_threads():

--- a/services/office/api/files.py
+++ b/services/office/api/files.py
@@ -258,7 +258,7 @@ async def get_files(
 
         # Build response data
         response_data = {
-            "files": [file.dict() for file in all_files],
+            "files": [file.model_dump() for file in all_files],
             "total_count": len(all_files),
             "providers_used": providers_used,
             "provider_errors": provider_errors,
@@ -481,7 +481,7 @@ async def search_files(
 
         # Build response data
         response_data = {
-            "files": [file.dict() for file in all_results],
+            "files": [file.model_dump() for file in all_results],
             "total_count": len(all_results),
             "providers_used": providers_used,
             "provider_errors": provider_errors,
@@ -598,7 +598,7 @@ async def get_file(
 
                 # Build response data
                 response_data = {
-                    "file": normalized_file.dict(),
+                    "file": normalized_file.model_dump(),
                     "provider": provider,
                     "request_metadata": {
                         "user_id": user_id,

--- a/services/user/schemas/integration.py
+++ b/services/user/schemas/integration.py
@@ -8,7 +8,7 @@ including integration status, token management, and provider-specific data.
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from services.user.models.integration import (
     IntegrationProvider,
@@ -89,8 +89,7 @@ class IntegrationResponse(BaseModel):
     created_at: datetime = Field(..., description="Integration creation time")
     updated_at: datetime = Field(..., description="Last update time")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class IntegrationListResponse(BaseModel):
@@ -385,8 +384,7 @@ class IntegrationErrorResponse(BaseModel):
         description="Error timestamp",
     )
 
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 # Validation schemas

--- a/services/user/schemas/preferences.py
+++ b/services/user/schemas/preferences.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from services.user.utils.validation import (
     check_sql_injection_patterns,
@@ -134,10 +134,8 @@ class UIPreferencesSchema(BaseModel):
     show_tooltips: bool = Field(default=True, description="Show helpful tooltips")
     animations_enabled: bool = Field(default=True, description="Enable UI animations")
 
-    class Config:
-        """Pydantic config."""
-
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "theme": "dark",
                 "language": "en",
@@ -149,6 +147,7 @@ class UIPreferencesSchema(BaseModel):
                 "animations_enabled": True,
             }
         }
+    )
 
 
 # Notification Preferences Schema
@@ -207,10 +206,8 @@ class NotificationPreferencesSchema(BaseModel):
         # Use comprehensive time validation
         return validate_time_format(v)
 
-    class Config:
-        """Pydantic config."""
-
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "email_notifications": True,
                 "push_notifications": True,
@@ -226,6 +223,7 @@ class NotificationPreferencesSchema(BaseModel):
                 "quiet_hours_end": "08:00",
             }
         }
+    )
 
 
 # AI Preferences Schema
@@ -298,10 +296,8 @@ class AIPreferencesSchema(BaseModel):
         valid_lengths = ["short", "medium", "long"]
         return validate_enum_value(sanitized, valid_lengths, "response_length")
 
-    class Config:
-        """Pydantic config."""
-
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "preferred_provider": "openai",
                 "preferred_model": "gpt-4",
@@ -314,6 +310,7 @@ class AIPreferencesSchema(BaseModel):
                 "max_tokens": 2000,
             }
         }
+    )
 
 
 # Integration Preferences Schema
@@ -366,10 +363,8 @@ class IntegrationPreferencesSchema(BaseModel):
         valid_strategies = ["prompt", "local_wins", "remote_wins", "create_copy"]
         return validate_enum_value(sanitized, valid_strategies, "conflict_resolution")
 
-    class Config:
-        """Pydantic config."""
-
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "auto_sync": True,
                 "sync_frequency": 30,
@@ -382,6 +377,7 @@ class IntegrationPreferencesSchema(BaseModel):
                 "conflict_resolution": "prompt",
             }
         }
+    )
 
 
 # Privacy Preferences Schema
@@ -417,10 +413,8 @@ class PrivacyPreferencesSchema(BaseModel):
         default=True, description="Encrypt sensitive data"
     )
 
-    class Config:
-        """Pydantic config."""
-
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "data_collection": True,
                 "analytics": True,
@@ -432,6 +426,7 @@ class PrivacyPreferencesSchema(BaseModel):
                 "encrypt_sensitive_data": True,
             }
         }
+    )
 
 
 # Complete Preferences Response Schema
@@ -452,10 +447,8 @@ class UserPreferencesResponse(BaseModel):
     created_at: datetime = Field(description="Creation timestamp")
     updated_at: datetime = Field(description="Last update timestamp")
 
-    class Config:
-        """Pydantic config."""
-
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "user_id": "user_123",
                 "ui": {
@@ -474,6 +467,7 @@ class UserPreferencesResponse(BaseModel):
                 "updated_at": "2024-01-01T12:00:00Z",
             }
         }
+    )
 
 
 # Preferences Update Schema
@@ -496,15 +490,14 @@ class UserPreferencesUpdate(BaseModel):
         None, description="Privacy preferences to update"
     )
 
-    class Config:
-        """Pydantic config."""
-
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "ui": {"theme": "dark", "language": "en"},
                 "notifications": {"email_notifications": False},
             }
         }
+    )
 
 
 # Preferences Reset Schema
@@ -530,10 +523,9 @@ class PreferencesResetRequest(BaseModel):
                 )
         return v
 
-    class Config:
-        """Pydantic config."""
-
-        json_schema_extra = {"example": {"categories": ["ui", "notifications"]}}
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"categories": ["ui", "notifications"]}}
+    )
 
 
 # Preferences Export Schema
@@ -545,10 +537,8 @@ class PreferencesExportResponse(BaseModel):
     exported_at: datetime = Field(description="Export timestamp")
     version: str = Field(default="1.0", description="Export format version")
 
-    class Config:
-        """Pydantic config."""
-
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "user_id": "user_123",
                 "preferences": {
@@ -559,6 +549,7 @@ class PreferencesExportResponse(BaseModel):
                 "version": "1.0",
             }
         }
+    )
 
 
 # Preferences Import Schema
@@ -587,10 +578,8 @@ class PreferencesImportRequest(BaseModel):
         valid_strategies = ["replace", "merge", "skip_existing"]
         return validate_enum_value(sanitized, valid_strategies, "merge_strategy")
 
-    class Config:
-        """Pydantic config."""
-
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "preferences": {
                     "ui": {"theme": "dark"},
@@ -600,3 +589,4 @@ class PreferencesImportRequest(BaseModel):
                 "merge_strategy": "merge",
             }
         }
+    )

--- a/services/user/schemas/user.py
+++ b/services/user/schemas/user.py
@@ -191,7 +191,7 @@ class UserResponse(UserBase):
     created_at: datetime = Field(..., description="When the user was created")
     updated_at: datetime = Field(..., description="When the user was last updated")
 
-    @field_serializer('created_at', 'updated_at')
+    @field_serializer("created_at", "updated_at")
     def serialize_dt(self, dt: datetime, _info):
         return dt.isoformat() if dt else None
 
@@ -220,7 +220,7 @@ class UserDeleteResponse(BaseModel):
     )
     deleted_at: datetime = Field(..., description="When the user was deleted")
 
-    @field_serializer('deleted_at')
+    @field_serializer("deleted_at")
     def serialize_dt(self, dt: datetime, _info):
         return dt.isoformat() if dt else None
 

--- a/services/user/schemas/user.py
+++ b/services/user/schemas/user.py
@@ -173,11 +173,6 @@ class UserUpdate(BaseModel):
         # Use comprehensive email validation
         return validate_email_address(v)
 
-    model_config = ConfigDict(
-        # Allow partial updates - all fields are optional
-        exclude_none=True
-    )
-
 
 class UserResponse(UserBase):
     """Schema for user response data."""

--- a/services/user/settings.py
+++ b/services/user/settings.py
@@ -6,8 +6,8 @@ Uses Pydantic Settings to manage environment variables and configuration.
 
 from typing import List, Optional
 
-from pydantic import AliasChoices, ConfigDict, Field
-from pydantic_settings import BaseSettings
+from pydantic import AliasChoices, Field # Removed ConfigDict
+from pydantic_settings import BaseSettings, SettingsConfigDict # Added SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -107,7 +107,7 @@ class Settings(BaseSettings):
     log_level: str = Field(default="INFO", description="Logging level")
     log_format: str = Field(default="json", description="Log format (json or text)")
 
-    model_config = ConfigDict(
+    model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,

--- a/services/user/settings.py
+++ b/services/user/settings.py
@@ -6,8 +6,11 @@ Uses Pydantic Settings to manage environment variables and configuration.
 
 from typing import List, Optional
 
-from pydantic import AliasChoices, Field # Removed ConfigDict
-from pydantic_settings import BaseSettings, SettingsConfigDict # Added SettingsConfigDict
+from pydantic import AliasChoices, Field  # Removed ConfigDict
+from pydantic_settings import (  # Added SettingsConfigDict
+    BaseSettings,
+    SettingsConfigDict,
+)
 
 
 class Settings(BaseSettings):

--- a/services/user/settings.py
+++ b/services/user/settings.py
@@ -6,7 +6,7 @@ Uses Pydantic Settings to manage environment variables and configuration.
 
 from typing import List, Optional
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, ConfigDict, Field
 from pydantic_settings import BaseSettings
 
 
@@ -107,11 +107,12 @@ class Settings(BaseSettings):
     log_level: str = Field(default="INFO", description="Logging level")
     log_format: str = Field(default="json", description="Log format (json or text)")
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-        case_sensitive = False
-        extra = "ignore"  # Ignore extra environment variables from other services
+    model_config = ConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",  # Ignore extra environment variables from other services
+    )
 
 
 # Global settings instance

--- a/services/user/tests/test_base.py
+++ b/services/user/tests/test_base.py
@@ -118,19 +118,25 @@ class BaseUserManagementIntegrationTest(BaseUserManagementTest):
 
     def _override_auth(self):
         """Override authentication for testing."""
+        from unittest.mock import AsyncMock
+
         from services.user.auth.clerk import get_current_user
 
         async def mock_get_current_user():
             return "user_123"
 
-        async def mock_verify_user_ownership(
-            current_user_id: str, resource_user_id: str
-        ):
-            return None
+        # This async def function can still be used as a side_effect if needed,
+        # but we'll create an AsyncMock instance directly for the patch.
+        # async def mock_verify_user_ownership_side_effect(
+        #     current_user_id: str, resource_user_id: str
+        # ):
+        #     return None
+
+        mock_verify_ownership_instance = AsyncMock(return_value=None)
 
         self.app.dependency_overrides[get_current_user] = mock_get_current_user
         patcher = patch(
             "services.user.auth.clerk.verify_user_ownership",
-            side_effect=mock_verify_user_ownership,
+            new=mock_verify_ownership_instance,
         )
         self._patcher = patcher.start()

--- a/services/user/tests/test_settings.py
+++ b/services/user/tests/test_settings.py
@@ -8,7 +8,8 @@ and configuration management.
 import os
 from unittest.mock import patch
 
-from pydantic_settings import SettingsConfigDict # Added SettingsConfigDict
+from pydantic_settings import SettingsConfigDict  # Added SettingsConfigDict
+
 from services.user.settings import Settings
 
 

--- a/services/user/tests/test_settings.py
+++ b/services/user/tests/test_settings.py
@@ -8,17 +8,20 @@ and configuration management.
 import os
 from unittest.mock import patch
 
+from pydantic import ConfigDict
+
 from services.user.settings import Settings
 
 
 class _TestableSettings(Settings):
     """Test version of Settings that doesn't load from .env file."""
 
-    class Config:
-        env_file = None  # Don't load from .env file in tests
-        env_file_encoding = "utf-8"
-        case_sensitive = False
-        extra = "ignore"
+    model_config = ConfigDict(
+        env_file=None,  # Don't load from .env file in tests
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
 
 
 class TestSettings:

--- a/services/user/tests/test_settings.py
+++ b/services/user/tests/test_settings.py
@@ -8,15 +8,14 @@ and configuration management.
 import os
 from unittest.mock import patch
 
-from pydantic import ConfigDict
-
+from pydantic_settings import SettingsConfigDict # Added SettingsConfigDict
 from services.user.settings import Settings
 
 
 class _TestableSettings(Settings):
     """Test version of Settings that doesn't load from .env file."""
 
-    model_config = ConfigDict(
+    model_config = SettingsConfigDict(
         env_file=None,  # Don't load from .env file in tests
         env_file_encoding="utf-8",
         case_sensitive=False,

--- a/services/user/tests/test_webhook_endpoints.py
+++ b/services/user/tests/test_webhook_endpoints.py
@@ -214,7 +214,7 @@ class TestClerkWebhookEndpoint(BaseUserManagementTest):
 
         response = self.client.post(
             "/webhooks/clerk",
-            data=invalid_payload,
+            content=invalid_payload,
             headers={
                 "svix-signature": "v1=test_signature",
                 "svix-timestamp": "1234567890",
@@ -281,7 +281,7 @@ class TestClerkWebhookEndpoint(BaseUserManagementTest):
 
         response = self.client.post(
             "/webhooks/clerk",
-            data="{invalid json}",
+            content="{invalid json}",
             headers={
                 "svix-signature": "v1=test_signature",
                 "svix-timestamp": "1234567890",


### PR DESCRIPTION
This commit addresses several deprecation warnings across the services:

1.  **Pydantic V2 Migration:**
    *   Replaced `json_encoders` with `field_serializer` in Pydantic models (e.g., `services/user/schemas/user.py`).
    *   Replaced `.dict()` calls with `.model_dump()` in various files (e.g., `services/office/app/main.py`, `services/office/tests/test_integration.py`, `services/office/api/files.py`).
    *   Converted Pydantic `class Config` to `model_config = ConfigDict(...)` in multiple schema and settings files (e.g., `services/chat/settings.py`, `services/user/schemas/integration.py`, `services/user/schemas/preferences.py`, `services/user/settings.py`).

2.  **FastAPI Lifespan Events:**
    *   Refactored `on_event("startup")` handlers to use the `lifespan` context manager in `services/office/app/main.py` and `services/user/main.py`.

3.  **HTTPX `encode_request`:**
    *   Updated `httpx.Client.post` calls in `services/user/tests/test_webhook_endpoints.py` to use `content=` instead of `data=` for raw JSON string payloads.

4.  **SQLAlchemy `OperationalError` in Tests:**
    *   Added a `pytest_asyncio.fixture` to `services/chat/tests/test_history_manager.py` to ensure database initialization before tests.

**Testing:**
*   All tests are passing after these changes.

**Remaining Issues (Further Investigation Needed):**
*   A `RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited` persists. This warning is related to the patching of `services.user.auth.clerk.verify_user_ownership` and likely stems from an unawaited call to this (mocked) async function within the test bodies of `services/user/tests/test_integration_endpoints.py` or `services/user/tests/test_main.py`. I made several attempts to fix this by adjusting the mock setup in `services/user/tests/test_base.py`.
*   A few Pydantic `class Config` deprecation warnings (4 instances reported by tests) also remain, requiring further investigation to locate their source.