### PR TITLE
feat: add conventional commit check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,3 +205,17 @@ jobs:
         # Test that docker-compose builds successfully
         docker compose config
         docker compose build --no-cache
+
+  conventional-commits:
+    name: Conventional Commits Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetches all history for accurate commit message linting
+
+      - name: Clone git-presubmit-linter
+        run: git clone https://github.com/google/git-presubmit-linter.git ../git-presubmit-linter
+
+      - name: Run mandate-conventional-changelog.sh
+        run: ../git-presubmit-linter/tools/mandate-conventional-changelog.sh


### PR DESCRIPTION
This commit adds a new job to the CI workflow to enforce conventional commit messages.

The new `conventional-commits` job uses the `google/git-presubmit-linter` to validate that commit messages adhere to the conventional commit format. This will help maintain a consistent and readable commit history.