### PR TITLE
fix: draft filters issue

### DIFF
--- a/frontend/components/drafts/draft-filters.tsx
+++ b/frontend/components/drafts/draft-filters.tsx
@@ -23,7 +23,7 @@ export function DraftFilters({
     type?: DraftType | DraftType[];
     status?: DraftStatus | DraftStatus[];
     search?: string;
-    onChange: (filters: { type?: DraftType | DraftType[]; status?: DraftStatus | DraftStatus[]; search?: string }) => void;
+    onChange: (filters: { type?: DraftType | DraftType[]; status?: DraftStatus | DraftStatus[]; search: string }) => void;
     hideTypeAndStatus?: boolean;
 }) {
     // Only use local search state if search input is rendered (hideTypeAndStatus)
@@ -76,7 +76,7 @@ export function DraftFilters({
                                     ? [...selectedTypes, t]
                                     : selectedTypes.filter((type) => type !== t);
                                 setSelectedTypes(newTypes);
-                                onChange({ type: newTypes, status: selectedStatuses, search });
+                                onChange({ type: newTypes, status: selectedStatuses, search: search || '' });
                             }}
                         >
                             {t.charAt(0).toUpperCase() + t.slice(1)}
@@ -93,7 +93,7 @@ export function DraftFilters({
                                     ? [...selectedStatuses, s]
                                     : selectedStatuses.filter((status) => status !== s);
                                 setSelectedStatuses(newStatuses);
-                                onChange({ type: selectedTypes, status: newStatuses, search });
+                                onChange({ type: selectedTypes, status: newStatuses, search: search || '' });
                             }}
                         >
                             {s.charAt(0).toUpperCase() + s.slice(1)}

--- a/frontend/components/drafts/drafts-list.tsx
+++ b/frontend/components/drafts/drafts-list.tsx
@@ -41,6 +41,8 @@ export default function DraftsList() {
                         onChange={f => setFilters(prev => ({
                             ...prev,
                             ...f,
+                            // Ensure search is always a string, never undefined
+                            search: f.search ?? prev.search,
                             type: f.type ? (Array.isArray(f.type) ? f.type : [f.type]) : [],
                             status: f.status ? (Array.isArray(f.status) ? f.status : [f.status]) : [],
                         }))}


### PR DESCRIPTION
I've successfully reviewed and fixed the bug reported by BugBot. Here's what I found and fixed:

The bug was **still relevant** and existed in the current codebase. The issue was:

1. **Root Cause**: When toggling type or status filters in `DraftFilters`, the `onChange` callback was being called with `search: search` where `search` could be `undefined` (since it's an optional prop).

2. **Problem**: In `DraftsList`, the state update `setFilters(prev => ({ ...prev, ...f }))` would spread the incoming filter object, causing `undefined` to overwrite the existing search value, clearing the search input.

3. **Type Safety Issue**: The `DraftFiltersState` type expected `search: string`, but the `onChange` prop allowed `search?: string`, creating a type mismatch.

1. **Fixed `DraftFilters.tsx`**:
   - Changed `onChange({ type: newTypes, status: selectedStatuses, search })` to `onChange({ type: newTypes, status: selectedStatuses, search: search || '' })` in both type and status filter handlers
   - Updated the `onChange` prop type from `search?: string` to `search: string` to enforce that search is always a string

2. **Enhanced `DraftsList.tsx`**:
   - Added defensive handling: `search: f.search ?? prev.search` to ensure the search value is never overwritten with `undefined`
   - This provides a fallback to the previous search value if the incoming filter doesn't specify a search value

- ✅ Build completed successfully with no TypeScript errors
- ✅ Linting passed with no warnings or errors
- ✅ The fix ensures search state persists across filter changes
- ✅ Type safety is maintained throughout

- ✅ Changing type or status filters no longer clears the search input
- ✅ No TypeScript errors for `search: undefined`
- ✅ Search state persists across filter changes unless explicitly cleared

The bug has been completely resolved and the code is now more robust against similar issues in the future.