### PR TITLE
fix: RuntimeWarning in integration service tests

### DIFF
--- a/services/user/tests/test_integration_service_coverage.py
+++ b/services/user/tests/test_integration_service_coverage.py
@@ -173,6 +173,7 @@ class TestIntegrationServiceCoverage(BaseUserManagementTest):
         )
 
         mock_session = AsyncMock()
+        mock_session.add = MagicMock()
 
         # Mock no tokens
         mock_result = MagicMock()


### PR DESCRIPTION
The `test_validate_status_corrects_active_status_when_no_tokens` test was causing a `RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited` because the `add` method on the `AsyncMock` session object was not being mocked correctly. This change explicitly mocks `session.add` as a `MagicMock` to prevent it from being treated as a coroutine.