### PR TITLE
feat: Implement X-Request-Id propagation

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -65,7 +65,7 @@ def test(session):
     """Run tests for all services."""
     # Install common dependencies
     session.install(
-        "pytest", "pytest-cov", "pytest-timeout", "pytest-mock", "pytest-asyncio", "pytest-xdist"
+        "pytest", "pytest-cov", "pytest-timeout", "pytest-mock", "pytest-asyncio", "pytest-xdist", "respx"
     )
 
     # Install services
@@ -82,7 +82,7 @@ def test(session):
 def test_fast(session):
     """Run fast tests only."""
     session.install(
-        "pytest", "pytest-cov", "pytest-timeout", "pytest-mock", "pytest-asyncio"
+        "pytest", "pytest-cov", "pytest-timeout", "pytest-mock", "pytest-asyncio", "respx"
     )
     session.install("-e", "services/common")
     session.install("-e", "services/user")
@@ -104,7 +104,7 @@ def test_fast(session):
 def test_cov(session):
     """Run tests with coverage."""
     session.install(
-        "pytest", "pytest-cov", "pytest-timeout", "pytest-mock", "pytest-asyncio"
+        "pytest", "pytest-cov", "pytest-timeout", "pytest-mock", "pytest-asyncio", "respx"
     )
     session.install("-e", "services/common")
     session.install("-e", "services/user")
@@ -144,7 +144,7 @@ def test_cov(session):
 def test_serial(session):
     """Run tests serially (not in parallel)."""
     session.install(
-        "pytest", "pytest-cov", "pytest-timeout", "pytest-mock", "pytest-asyncio"
+        "pytest", "pytest-cov", "pytest-timeout", "pytest-mock", "pytest-asyncio", "respx"
     )
     session.install("-e", "services/common")
     session.install("-e", "services/user")

--- a/services/chat/service_client.py
+++ b/services/chat/service_client.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from services.chat.settings import get_settings
-from services.common.logging_config import get_logger
+from services.common.logging_config import get_logger, request_id_var
 
 logger = get_logger(__name__)
 
@@ -34,6 +34,11 @@ class ServiceClient:
     def _get_headers_for_service(self, service_name: str) -> Dict[str, str]:
         """Get authentication headers for a specific service."""
         headers = {"Content-Type": "application/json"}
+
+        # Propagate request ID for distributed tracing
+        request_id = request_id_var.get()
+        if request_id and request_id != "uninitialized":
+            headers["X-Request-Id"] = request_id
 
         if service_name == "user-management" and get_settings().api_chat_user_key:
             headers["X-API-Key"] = get_settings().api_chat_user_key  # type: ignore[assignment]

--- a/services/chat/tests/test_chat_service_e2e.py
+++ b/services/chat/tests/test_chat_service_e2e.py
@@ -10,7 +10,9 @@ import sys
 from unittest.mock import patch
 
 import pytest
+import respx
 from fastapi.testclient import TestClient
+from httpx import Response
 
 # Test API key for authentication
 TEST_API_KEY = "test-frontend-chat-key"
@@ -26,6 +28,8 @@ def test_env():
         "LLM_MODEL": "fake-model",
         "LLM_PROVIDER": "fake",
         "API_FRONTEND_CHAT_KEY": TEST_API_KEY,
+        "USER_MANAGEMENT_SERVICE_URL": "http://localhost:8001",
+        "OFFICE_SERVICE_URL": "http://localhost:8003",
     }
     with patch.dict("os.environ", env_vars):
         yield env_vars
@@ -180,3 +184,40 @@ def test_multiple_blank_thread_creates_distinct_threads(app):
     thread_ids = {t["thread_id"] for t in threads}
     assert thread_id1 in thread_ids
     assert thread_id2 in thread_ids
+
+
+@respx.mock
+def test_request_id_propagation(app):
+    """
+    Test that X-Request-Id is properly propagated to downstream services.
+    """
+    # Arrange
+    client = TestClient(app)
+    test_request_id = "test-req-id-123"
+    user_id = "test-user-for-req-id"
+
+    # Mock the downstream user service
+    # The URL must match what's configured in the test_env fixture
+    user_service_url = "http://localhost:8001"
+
+    # Mock the get_user_preferences call
+    preferences_route = respx.get(f"{user_service_url}/internal/users/{user_id}/preferences").mock(
+        return_value=Response(200, json={"timezone": "UTC"})
+    )
+
+    # Act
+    headers = {
+        "X-API-Key": TEST_API_KEY,
+        "X-Request-Id": test_request_id,
+        "X-User-Id": user_id,
+    }
+    # The /chat endpoint triggers a call to get_user_preferences
+    response = client.post("/chat", headers=headers, json={"message": "Hello"})
+
+    # Assert
+    assert response.status_code == 200
+    assert preferences_route.called, "The downstream service was not called."
+
+    # Check the headers of the request made to the downstream service
+    last_request = preferences_route.calls.last.request
+    assert last_request.headers.get("x-request-id") == test_request_id

--- a/services/office/core/token_manager.py
+++ b/services/office/core/token_manager.py
@@ -64,11 +64,18 @@ class TokenManager:
 
     async def __aenter__(self) -> "TokenManager":
         """Async context manager entry"""
+        from services.common.logging_config import request_id_var
+
         # Use API key for user management service if available
         headers: dict[str, str] = {}
         api_key = get_settings().api_office_user_key
         if api_key:
             headers["X-API-Key"] = api_key
+
+        # Propagate request ID for distributed tracing
+        request_id = request_id_var.get()
+        if request_id and request_id != "uninitialized":
+            headers["X-Request-Id"] = request_id
 
         self.http_client = httpx.AsyncClient(
             timeout=httpx.Timeout(10.0),  # 10 second timeout


### PR DESCRIPTION
This commit implements the propagation of the `X-Request-Id` header across all services for distributed tracing.

Key changes:
- Updated the common logging middleware to extract the `X-Request-Id` from incoming request headers, or generate a new one if not present.
- Stored the `request_id` in a context variable to make it accessible throughout the application.
- Modified service clients in the chat and office services to propagate the `X-Request-Id` header in all outgoing HTTP requests.
- Added an integration test to verify the end-to-end propagation of the `X-Request-Id` header.