### PR TITLE
refactor(frontend): remove user_id from office service API calls

### DIFF
--- a/frontend/components/calendar-test.tsx
+++ b/frontend/components/calendar-test.tsx
@@ -24,7 +24,6 @@ export function CalendarTest() {
 
         try {
             const response = await gatewayClient.getCalendarEvents(
-                session.user.id,
                 session.provider ? [session.provider] : ['google', 'microsoft'],
                 5,
                 new Date().toISOString().split('T')[0],

--- a/frontend/components/tool-content.tsx
+++ b/frontend/components/tool-content.tsx
@@ -40,7 +40,6 @@ export function ToolContent() {
         setCalendarError(null);
         try {
             const response = await gatewayClient.getCalendarEvents(
-                session.user.id,
                 activeProviders,
                 10,
                 new Date().toISOString().split('T')[0],

--- a/frontend/components/views/email-view.tsx
+++ b/frontend/components/views/email-view.tsx
@@ -59,7 +59,7 @@ const EmailView: React.FC<EmailViewProps> = ({ toolDataLoading = false, activeTo
                 if (!userId) throw new Error('No user id found in session');
 
                 // Use the user's actual connected providers
-                const emailsResp = await gatewayClient.getEmails(userId, activeProviders, 50, 0) as { data?: { messages?: EmailMessage[] } };
+                const emailsResp = await gatewayClient.getEmails(activeProviders, 50, 0) as { data?: { messages?: EmailMessage[] } };
                 if (isMounted) setThreads(emailsResp.data?.messages || []);
                 setError(null);
             } catch (e: unknown) {

--- a/frontend/lib/gateway-client.ts
+++ b/frontend/lib/gateway-client.ts
@@ -196,7 +196,6 @@ export class GatewayClient {
 
     // Office Service
     async getCalendarEvents(
-        user_id: string,
         providers?: string[],
         limit: number = 50,
         start_date?: string,
@@ -206,7 +205,6 @@ export class GatewayClient {
         time_zone: string = 'UTC'
     ) {
         const params = new URLSearchParams();
-        params.append('user_id', user_id);
         if (providers && providers.length > 0) {
             providers.forEach(provider => params.append('providers', provider));
         }
@@ -230,13 +228,11 @@ export class GatewayClient {
     }
 
     async getEmails(
-        user_id: string,
         providers: string[],
         limit?: number,
         offset?: number
     ): Promise<ApiResponse<GetEmailsResponse>> {
         const params = new URLSearchParams();
-        params.append('user_id', user_id);
         if (limit) params.append('limit', limit.toString());
         if (offset) params.append('offset', offset.toString());
 

--- a/tasks/tasks-auth-unification.md
+++ b/tasks/tasks-auth-unification.md
@@ -111,19 +111,21 @@ The goal is to ensure secure, scalable, and maintainable authentication for both
 - [x] **HIGH PRIORITY**: Add/verify tests for user extraction from headers
 - [x] **HIGH PRIORITY**: Update all tests to use new authentication pattern
 - [ ] **MEDIUM PRIORITY**: Add any missing `/internal` endpoints if needed for service-to-service calls
+    - No `/internal` endpoints are needed at this time because there are no background jobs or service-to-service requirements yet.
 
 #### 4.4. Office Service Updates (Depends on Gateway)
 - [x] **HIGH PRIORITY**: Add new endpoints that extract user from `X-User-Id` header (not query params)
 - [x] **HIGH PRIORITY**: Update endpoint handlers to use gateway header
 - [x] **HIGH PRIORITY**: Add/verify tests for user extraction from headers
 - [x] **HIGH PRIORITY**: Update all tests to use new authentication pattern
-- [ ] **MEDIUM PRIORITY**: Add any missing `/internal` endpoints if needed for service-to-service calls
+- [x] **MEDIUM PRIORITY**: Add any missing `/internal` endpoints if needed for service-to-service calls
+    - No `/internal` endpoints are needed at this time because there are no background jobs or service-to-service requirements yet.
 
 ### Phase 3: Frontend Updates (Depends on Phase 2)
 
 #### 4.5. Frontend API Client Updates (Depends on Backend)
-- [ ] **HIGH PRIORITY**: Update all API client calls to use new endpoints (no user_id in query params)
-- [ ] **HIGH PRIORITY**: Update office service calls to use new endpoints (no user_id in query params)
+- [x] **HIGH PRIORITY**: Update all API client calls to use new endpoints (no user_id in query params)
+- [x] **HIGH PRIORITY**: Update office service calls to use new endpoints (no user_id in query params)
 - [ ] **HIGH PRIORITY**: Ensure no API keys are present in client-side code
 - [ ] **HIGH PRIORITY**: Add/verify tests for correct session/JWT usage
 - [ ] **MEDIUM PRIORITY**: Update any hardcoded user ID references


### PR DESCRIPTION
- Updated gateway-client.ts, tool-content.tsx, calendar-test.tsx, and email-view.tsx to stop sending user_id in query params for office/calendar/email endpoints
- Frontend now relies on backend to extract user context from JWT/session, per unified auth design
- Prepares codebase for stricter backend auth and cleaner API contracts