### PR TITLE
refactor(fe): centralize environment config and add auto-validation

### DIFF
--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -12,23 +12,11 @@ import { NextAuthOptions } from 'next-auth';
 import AzureADProvider from 'next-auth/providers/azure-ad';
 import GoogleProvider from 'next-auth/providers/google';
 
-// Environment validation
-function validateEnvironment() {
-    const required = [
-        'NEXTAUTH_SECRET',
-        'USER_SERVICE_URL',
-        'API_FRONTEND_USER_KEY'
-    ];
-
-    for (const var_name of required) {
-        if (!process.env[var_name]) {
-            throw new Error(`${var_name} environment variable is required`);
-        }
-    }
-}
+// Import server-side environment validation
+import { validateServerEnv } from './env-server';
 
 // Validate environment on module load
-validateEnvironment();
+validateServerEnv();
 
 export const authOptions: NextAuthOptions = {
     providers: [

--- a/frontend/lib/env-server.ts
+++ b/frontend/lib/env-server.ts
@@ -1,0 +1,88 @@
+// Server-side environment variables - DO NOT import in client-side code
+// This file should only be used in server components, API routes, or other server-side contexts.
+
+export const serverEnv = {
+    // NextAuth configuration
+    NEXTAUTH_URL: process.env.NEXTAUTH_URL!,
+    NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET!,
+
+    // Service URLs (for server-side use)
+    CHAT_SERVICE_URL: process.env.CHAT_SERVICE_URL || 'http://localhost:8001',
+    USER_SERVICE_URL: process.env.USER_SERVICE_URL || 'http://localhost:8000',
+    OFFICE_SERVICE_URL: process.env.OFFICE_SERVICE_URL || 'http://localhost:8002',
+
+    // API Keys for service-to-service communication (SERVER-SIDE ONLY)
+    API_FRONTEND_CHAT_KEY: process.env.API_FRONTEND_CHAT_KEY!,
+    API_FRONTEND_USER_KEY: process.env.API_FRONTEND_USER_KEY!,
+    API_FRONTEND_OFFICE_KEY: process.env.API_FRONTEND_OFFICE_KEY!,
+
+    // OAuth configuration
+    AZURE_AD_CLIENT_ID: process.env.AZURE_AD_CLIENT_ID!,
+    AZURE_AD_CLIENT_SECRET: process.env.AZURE_AD_CLIENT_SECRET!,
+    AZURE_AD_TENANT_ID: process.env.AZURE_AD_TENANT_ID!,
+} as const;
+
+// Validation functions for server-side environment variables
+export function validateServerEnv() {
+    const requiredEnvVars = [
+        'NEXTAUTH_URL',
+        'NEXTAUTH_SECRET',
+        'API_FRONTEND_CHAT_KEY',
+        'API_FRONTEND_USER_KEY',
+        'API_FRONTEND_OFFICE_KEY',
+        'AZURE_AD_CLIENT_ID',
+        'AZURE_AD_CLIENT_SECRET',
+        'AZURE_AD_TENANT_ID',
+    ] as const;
+
+    for (const envVar of requiredEnvVars) {
+        if (!process.env[envVar]) {
+            throw new Error(`Missing required server environment variable: ${envVar}`);
+        }
+    }
+}
+
+export function validateNextAuthEnv() {
+    const required = ['NEXTAUTH_URL', 'NEXTAUTH_SECRET'];
+    for (const envVar of required) {
+        if (!process.env[envVar]) {
+            throw new Error(`Missing required environment variable: ${envVar}`);
+        }
+    }
+}
+
+export function validateOAuthEnv() {
+    const required = ['AZURE_AD_CLIENT_ID', 'AZURE_AD_CLIENT_SECRET', 'AZURE_AD_TENANT_ID'];
+    for (const envVar of required) {
+        if (!process.env[envVar]) {
+            throw new Error(`Missing required environment variable: ${envVar}`);
+        }
+    }
+}
+
+export function validateChatServiceEnv() {
+    const required = ['API_FRONTEND_CHAT_KEY'];
+    for (const envVar of required) {
+        if (!process.env[envVar]) {
+            throw new Error(`Missing required environment variable: ${envVar}`);
+        }
+    }
+}
+
+export function validateUserServiceEnv() {
+    const required = ['API_FRONTEND_USER_KEY'];
+    for (const envVar of required) {
+        if (!process.env[envVar]) {
+            throw new Error(`Missing required environment variable: ${envVar}`);
+        }
+    }
+}
+
+export function validateOfficeServiceEnv() {
+    const required = ['API_FRONTEND_OFFICE_KEY'];
+    for (const envVar of required) {
+        if (!process.env[envVar]) {
+            throw new Error(`Missing required environment variable: ${envVar}`);
+        }
+    }
+} 

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -1,90 +1,18 @@
-// Environment variable validation for frontend
-export const env = {
-    // NextAuth configuration
-    NEXTAUTH_URL: process.env.NEXTAUTH_URL!,
-    NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET!,
+// Client-side environment variables - SAFE for client-side use
+// This file only contains environment variables that are safe to expose to the client.
+// For server-side environment variables, use @/lib/env-server instead.
 
+export const env = {
     // Gateway URL (for client-side use)
     GATEWAY_URL: process.env.NEXT_PUBLIC_GATEWAY_URL || 'http://localhost:3001',
-
-    // Service URLs (for server-side use)
-    CHAT_SERVICE_URL: process.env.CHAT_SERVICE_URL || 'http://localhost:8001',
-    USER_SERVICE_URL: process.env.USER_SERVICE_URL || 'http://localhost:8000',
-    OFFICE_SERVICE_URL: process.env.OFFICE_SERVICE_URL || 'http://localhost:8002',
-
-    // API Keys for service-to-service communication
-    API_FRONTEND_CHAT_KEY: process.env.API_FRONTEND_CHAT_KEY!,
-    API_FRONTEND_USER_KEY: process.env.API_FRONTEND_USER_KEY!,
-    API_FRONTEND_OFFICE_KEY: process.env.API_FRONTEND_OFFICE_KEY!,
-
-    // OAuth configuration
-    AZURE_AD_CLIENT_ID: process.env.AZURE_AD_CLIENT_ID!,
-    AZURE_AD_CLIENT_SECRET: process.env.AZURE_AD_CLIENT_SECRET!,
-    AZURE_AD_TENANT_ID: process.env.AZURE_AD_TENANT_ID!,
 } as const;
 
-// Validation functions for specific use cases
-export function validateNextAuthEnv() {
-    const required = ['NEXTAUTH_URL', 'NEXTAUTH_SECRET'];
+// Client-side environment validation
+export function validateClientEnv() {
+    const required = ['NEXT_PUBLIC_GATEWAY_URL'];
     for (const envVar of required) {
         if (!process.env[envVar]) {
-            throw new Error(`Missing required environment variable: ${envVar}`);
-        }
-    }
-}
-
-export function validateOAuthEnv() {
-    const required = ['AZURE_AD_CLIENT_ID', 'AZURE_AD_CLIENT_SECRET', 'AZURE_AD_TENANT_ID'];
-    for (const envVar of required) {
-        if (!process.env[envVar]) {
-            throw new Error(`Missing required environment variable: ${envVar}`);
-        }
-    }
-}
-
-export function validateChatServiceEnv() {
-    const required = ['API_FRONTEND_CHAT_KEY'];
-    for (const envVar of required) {
-        if (!process.env[envVar]) {
-            throw new Error(`Missing required environment variable: ${envVar}`);
-        }
-    }
-}
-
-export function validateUserServiceEnv() {
-    const required = ['API_FRONTEND_USER_KEY'];
-    for (const envVar of required) {
-        if (!process.env[envVar]) {
-            throw new Error(`Missing required environment variable: ${envVar}`);
-        }
-    }
-}
-
-export function validateOfficeServiceEnv() {
-    const required = ['API_FRONTEND_OFFICE_KEY'];
-    for (const envVar of required) {
-        if (!process.env[envVar]) {
-            throw new Error(`Missing required environment variable: ${envVar}`);
-        }
-    }
-}
-
-// Validate all environment variables (for startup validation)
-export function validateAllEnv() {
-    const requiredEnvVars = [
-        'NEXTAUTH_URL',
-        'NEXTAUTH_SECRET',
-        'API_FRONTEND_CHAT_KEY',
-        'API_FRONTEND_USER_KEY',
-        'API_FRONTEND_OFFICE_KEY',
-        'AZURE_AD_CLIENT_ID',
-        'AZURE_AD_CLIENT_SECRET',
-        'AZURE_AD_TENANT_ID',
-    ] as const;
-
-    for (const envVar of requiredEnvVars) {
-        if (!process.env[envVar]) {
-            throw new Error(`Missing required environment variable: ${envVar}`);
+            console.warn(`Missing optional client environment variable: ${envVar} (using default)`);
         }
     }
 } 

--- a/frontend/lib/gateway-client.ts
+++ b/frontend/lib/gateway-client.ts
@@ -1,6 +1,7 @@
 import { ApiResponse, CalendarEventsResponse, CreateCalendarEventRequest, GetEmailsResponse } from '@/types/office-service';
 import { getSession } from 'next-auth/react';
 import { IntegrationStatus } from './constants';
+import { env, validateClientEnv } from './env';
 
 interface GatewayClientOptions {
     method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
@@ -9,11 +10,9 @@ interface GatewayClientOptions {
 }
 
 export class GatewayClient {
-    private gatewayUrl: string;
-
     constructor() {
-        // Use gateway URL from environment, fallback to localhost
-        this.gatewayUrl = process.env.NEXT_PUBLIC_GATEWAY_URL || 'http://localhost:3001';
+        // Validate client-side environment variables on instantiation
+        validateClientEnv();
     }
 
     private async getAuthHeaders(): Promise<Record<string, string>> {
@@ -46,7 +45,7 @@ export class GatewayClient {
             config.body = JSON.stringify(body);
         }
 
-        const url = `${this.gatewayUrl}${endpoint}`;
+        const url = `${env.GATEWAY_URL}${endpoint}`;
 
         try {
             const response = await fetch(url, config);
@@ -102,7 +101,7 @@ export class GatewayClient {
             headers['Authorization'] = `Bearer ${session.accessToken}`;
         }
 
-        const response = await fetch(`${this.gatewayUrl}/api/chat/stream`, {
+        const response = await fetch(`${env.GATEWAY_URL}/api/chat/stream`, {
             method: 'POST',
             headers,
             body: JSON.stringify({
@@ -303,7 +302,7 @@ export class GatewayClient {
 
     // WebSocket connection helper
     createWebSocketConnection(endpoint: string): WebSocket {
-        const wsUrl = this.gatewayUrl.replace('http', 'ws');
+        const wsUrl = env.GATEWAY_URL.replace('http', 'ws');
         return new WebSocket(`${wsUrl}${endpoint}`);
     }
 }
@@ -385,4 +384,4 @@ export interface DraftListResponse {
     has_more: boolean;
 }
 
-export default gatewayClient; 
+export default gatewayClient;

--- a/tasks/tasks-auth-unification.md
+++ b/tasks/tasks-auth-unification.md
@@ -126,7 +126,12 @@ The goal is to ensure secure, scalable, and maintainable authentication for both
 #### 4.5. Frontend API Client Updates (Depends on Backend)
 - [x] **HIGH PRIORITY**: Update all API client calls to use new endpoints (no user_id in query params)
 - [x] **HIGH PRIORITY**: Update office service calls to use new endpoints (no user_id in query params)
-- [ ] **HIGH PRIORITY**: Ensure no API keys are present in client-side code
+- [x] **HIGH PRIORITY**: Ensure no API keys are present in client-side code
+    - Created separate server-side and client-side environment files
+    - Moved all API keys to server-side only files
+    - Client-side env.ts now only contains safe public variables
+    - Refactored gateway-client.ts to use centralized env.ts instead of direct process.env access
+    - Added validateClientEnv() call in GatewayClient constructor for automatic environment validation
 - [ ] **HIGH PRIORITY**: Add/verify tests for correct session/JWT usage
 - [ ] **MEDIUM PRIORITY**: Update any hardcoded user ID references
 


### PR DESCRIPTION
- Refactor gateway-client.ts to use centralized env.ts instead of direct process.env access
- Remove gatewayUrl instance variable, use env.GATEWAY_URL directly
- Add validateClientEnv() call in GatewayClient constructor for automatic environment validation
- Remove manual validation from page component
- Improve code consistency and developer experience with centralized config