### PR TITLE
feat: support and test 'expired' integration status for token refresh

### DIFF
--- a/frontend/components/tool-content.tsx
+++ b/frontend/components/tool-content.tsx
@@ -21,7 +21,12 @@ export function ToolContent() {
     const [calendarEvents, setCalendarEvents] = useState<CalendarEvent[]>([]);
     const [calendarLoading, setCalendarLoading] = useState(false);
     const [calendarError, setCalendarError] = useState<string | null>(null);
-    const { loading: integrationsLoading, activeProviders } = useIntegrations();
+    const { loading: integrationsLoading, activeProviders, triggerAutoRefreshIfNeeded } = useIntegrations();
+
+    // Call auto-refresh logic on every tool change
+    useEffect(() => {
+        triggerAutoRefreshIfNeeded();
+    }, [activeTool, triggerAutoRefreshIfNeeded]);
 
     // Compute a loading boolean for tool data readiness
     const toolDataLoading = integrationsLoading || !session?.user?.id;

--- a/frontend/components/views/email-view.tsx
+++ b/frontend/components/views/email-view.tsx
@@ -32,7 +32,7 @@ const EmailView: React.FC<EmailViewProps> = ({ toolDataLoading = false, activeTo
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [filters, setFilters] = useState<Record<string, unknown>>({});
-    const { loading: integrationsLoading, activeProviders, hasExpiredButRefreshableTokens, integrations } = useIntegrations();
+    const { loading: integrationsLoading, activeProviders, hasExpiredButRefreshableTokens } = useIntegrations();
 
     useEffect(() => {
         // Only fetch when the tab is actually activated

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -4,6 +4,7 @@ export const INTEGRATION_STATUS = {
     INACTIVE: 'inactive',
     ERROR: 'error',
     PENDING: 'pending',
+    EXPIRED: 'expired',
 } as const;
 
 export type IntegrationStatus = typeof INTEGRATION_STATUS[keyof typeof INTEGRATION_STATUS];

--- a/services/user/models/integration.py
+++ b/services/user/models/integration.py
@@ -34,6 +34,7 @@ class IntegrationStatus(str, Enum):
     INACTIVE = "inactive"  # Disconnected by user
     ERROR = "error"  # Connection error or expired tokens
     PENDING = "pending"  # OAuth flow in progress
+    EXPIRED = "expired"  # Token was valid but is now expired
 
 
 class Integration(SQLModel, table=True):

--- a/services/user/services/integration_service.py
+++ b/services/user/services/integration_service.py
@@ -1457,16 +1457,16 @@ class IntegrationService:
                 expires_at = expires_at.replace(tzinfo=timezone.utc)
 
             if expires_at <= datetime.now(timezone.utc):
-                # Token is expired but we have refresh token - should be ERROR until refreshed
-                if integration.status != IntegrationStatus.ERROR:
-                    integration.status = IntegrationStatus.ERROR
+                # Token is expired but we have refresh token - should be EXPIRED until refreshed
+                if integration.status != IntegrationStatus.EXPIRED:
+                    integration.status = IntegrationStatus.EXPIRED
                     integration.error_message = (
                         "Access token expired - refresh required"
                     )
                     integration.updated_at = datetime.now(timezone.utc)
                     session.add(integration)
                     await session.commit()  # Atomic commit for status correction
-                return IntegrationStatus.ERROR
+                return IntegrationStatus.EXPIRED
 
         # All checks passed - should be ACTIVE
         if integration.status != IntegrationStatus.ACTIVE:


### PR DESCRIPTION
- Backend: Add 'EXPIRED' status to IntegrationStatus and update validation logic to set status to EXPIRED when access token is expired but refresh token exists
- Frontend: Update and refactor logic to auto-refresh integrations with status 'expired' and a refresh token; remove debug logs
- Tests: Add unit test to IntegrationService to verify EXPIRED status is set correctly