### PR TITLE
refactor: Office service permission checks and API key authentication

### DIFF
--- a/services/common/api_key_auth.py
+++ b/services/common/api_key_auth.py
@@ -1,0 +1,200 @@
+"""
+Shared API key authentication and authorization helpers for Briefly services.
+
+Each service should define its own API_KEY_CONFIGS and get_settings function, and pass them to these helpers.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+from fastapi import Request
+
+from services.common.http_errors import AuthError, ServiceError
+from services.common.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class APIKeyConfig:
+    client: str
+    service: str
+    permissions: List[str]
+    settings_key: str  # The key name in settings to look up the actual API key value
+
+
+def build_api_key_mapping(
+    api_key_configs: Dict[str, APIKeyConfig], get_settings: Callable[[], Any]
+) -> Dict[str, APIKeyConfig]:
+    """
+    Build a mapping from actual API key values to their configurations.
+    """
+    settings = get_settings()
+    api_key_mapping = {}
+    for config_name, config in api_key_configs.items():
+        actual_key_value = getattr(settings, config.settings_key, None)
+        if actual_key_value:
+            api_key_mapping[actual_key_value] = config
+        else:
+            logger.warning(f"API key not found in settings: {config.settings_key}")
+    return api_key_mapping
+
+
+def get_api_key_from_request(request: Request) -> Optional[str]:
+    """
+    Extract API key from request headers (supports X-API-Key, Authorization: Bearer, X-Service-Key).
+    """
+    api_key = request.headers.get("X-API-Key")
+    if api_key:
+        return api_key
+    authorization = request.headers.get("Authorization")
+    if authorization and authorization.startswith("Bearer "):
+        return authorization[7:]
+    service_key = request.headers.get("X-Service-Key")
+    if service_key:
+        return service_key
+    return None
+
+
+def verify_api_key(
+    api_key: str, api_key_mapping: Dict[str, APIKeyConfig]
+) -> Optional[str]:
+    """
+    Verify an API key and return the service name it's authorized for.
+    """
+    if not api_key:
+        return None
+    key_config = api_key_mapping.get(api_key)
+    if not key_config:
+        return None
+    return key_config.service
+
+
+def get_client_from_api_key(
+    api_key: str, api_key_mapping: Dict[str, APIKeyConfig]
+) -> Optional[str]:
+    key_config = api_key_mapping.get(api_key)
+    return key_config.client if key_config else None
+
+
+def get_permissions_from_api_key(
+    api_key: str, api_key_mapping: Dict[str, APIKeyConfig]
+) -> List[str]:
+    key_config = api_key_mapping.get(api_key)
+    return key_config.permissions if key_config else []
+
+
+def has_permission(
+    api_key: str, required_permission: str, api_key_mapping: Dict[str, APIKeyConfig]
+) -> bool:
+    permissions = get_permissions_from_api_key(api_key, api_key_mapping)
+    return required_permission in permissions
+
+
+def get_client_permissions(
+    client_name: str, client_permissions: Dict[str, List[str]]
+) -> List[str]:
+    return client_permissions.get(client_name, [])
+
+
+def client_has_permission(
+    client_name: str, required_permission: str, client_permissions: Dict[str, List[str]]
+) -> bool:
+    permissions = get_client_permissions(client_name, client_permissions)
+    return required_permission in permissions
+
+
+def get_service_permissions(
+    service_name: str, service_permissions: Dict[str, List[str]]
+) -> List[str]:
+    return service_permissions.get(service_name, [])
+
+
+def validate_service_permissions(
+    service_name: str,
+    required_permissions: Optional[List[str]],
+    api_key: Optional[str],
+    api_key_mapping: Dict[str, APIKeyConfig],
+    service_permissions: Optional[Dict[str, List[str]]] = None,
+) -> bool:
+    """
+    Validate that a service has the required permissions.
+    """
+    if not required_permissions:
+        return True
+    if api_key:
+        key_permissions = get_permissions_from_api_key(api_key, api_key_mapping)
+        return all(perm in key_permissions for perm in required_permissions)
+    if service_permissions:
+        allowed_permissions = service_permissions.get(service_name, [])
+        return all(perm in allowed_permissions for perm in required_permissions)
+    return False
+
+
+# FastAPI dependencies (parameterized)
+def make_verify_service_authentication(
+    api_key_configs: Dict[str, APIKeyConfig], get_settings: Callable[[], Any]
+) -> Callable[[Request], str]:
+    def verify_service_authentication(request: Request) -> str:
+        """Synchronously verify the API key from the request and return the service name."""
+        api_key = get_api_key_from_request(request)
+        api_key_mapping = build_api_key_mapping(api_key_configs, get_settings)
+        if not api_key:
+            logger.warning("Missing API key in request headers")
+            raise AuthError(message="API key required", status_code=401)
+        service_name = verify_api_key(api_key, api_key_mapping)
+        if not service_name:
+            logger.warning(f"Invalid API key: {api_key[:8]}...")
+            raise AuthError(message="Invalid API key", status_code=401)
+        request.state.api_key = api_key
+        request.state.service_name = service_name
+        request.state.client_name = get_client_from_api_key(api_key, api_key_mapping)
+        logger.info(
+            f"Service authenticated: {service_name} (client: {request.state.client_name})"
+        )
+        return service_name
+
+    return verify_service_authentication
+
+
+def make_service_permission_required(
+    required_permissions: List[str],
+    api_key_configs: Dict[str, APIKeyConfig],
+    get_settings: Callable[[], Any],
+    service_permissions: Optional[Dict[str, List[str]]] = None,
+) -> Callable[[Request], Any]:
+    async def dependency(request: Request) -> str:
+        verify_service_authentication = make_verify_service_authentication(
+            api_key_configs, get_settings
+        )
+        service_name = verify_service_authentication(request)
+        api_key_mapping = build_api_key_mapping(api_key_configs, get_settings)
+        api_key = getattr(request.state, "api_key", None)
+        if not api_key:
+            raise ServiceError(
+                message="API key not found in request state", status_code=500
+            )
+        if not validate_service_permissions(
+            service_name,
+            required_permissions,
+            api_key,
+            api_key_mapping,
+            service_permissions,
+        ):
+            client_name = getattr(request.state, "client_name", "unknown")
+            logger.warning(
+                f"Permission denied: {client_name} lacks permissions {required_permissions}",
+                extra={
+                    "service": service_name,
+                    "client": client_name,
+                    "required_permissions": required_permissions,
+                    "api_key_prefix": api_key[:8] if api_key else None,
+                },
+            )
+            raise AuthError(
+                message=f"Insufficient permissions. Required: {required_permissions}",
+                status_code=403,
+            )
+        return service_name
+
+    return dependency

--- a/services/office/api/calendar.py
+++ b/services/office/api/calendar.py
@@ -21,7 +21,7 @@ from services.common.http_errors import (
     ValidationError,
 )
 from services.office.core.api_client_factory import APIClientFactory
-from services.office.core.auth import ServicePermissionRequired
+from services.office.core.auth import service_permission_required
 from services.office.core.cache_manager import cache_manager, generate_cache_key
 from services.office.core.clients.google import GoogleAPIClient
 from services.office.core.clients.microsoft import MicrosoftAPIClient
@@ -86,7 +86,7 @@ async def get_calendar_events(
     ),
     q: Optional[str] = Query(None, description="Search query to filter events"),
     time_zone: Optional[str] = Query("UTC", description="Time zone for date filtering"),
-    service_name: str = Depends(ServicePermissionRequired(["read_calendar"])),
+    service_name: str = Depends(service_permission_required(["read_calendar"])),
 ) -> ApiResponse:
     """
     Get unified calendar events from multiple providers.
@@ -298,7 +298,7 @@ async def get_calendar_events(
 async def get_calendar_event(
     request: Request,
     event_id: str = Path(..., description="Event ID (format: provider_originalId)"),
-    service_name: str = Depends(ServicePermissionRequired(["read_calendar"])),
+    service_name: str = Depends(service_permission_required(["read_calendar"])),
 ) -> ApiResponse:
     """
     Get a specific calendar event by ID.
@@ -381,7 +381,7 @@ async def get_calendar_event(
 async def create_calendar_event(
     request: Request,
     event_data: CreateCalendarEventRequest,
-    service_name: str = Depends(ServicePermissionRequired(["write_calendar"])),
+    service_name: str = Depends(service_permission_required(["write_calendar"])),
 ) -> ApiResponse:
     """
     Create a calendar event in a specific provider.
@@ -484,7 +484,7 @@ async def update_calendar_event(
     event_data: CreateCalendarEventRequest,
     event_id: str = Path(..., description="Event ID (format: provider_originalId)"),
     user_id: str = Query(..., description="ID of the user updating the event"),
-    service_name: str = Depends(ServicePermissionRequired(["write_calendar"])),
+    service_name: str = Depends(service_permission_required(["write_calendar"])),
 ) -> ApiResponse:
     """
     Update a calendar event by ID.
@@ -913,7 +913,7 @@ async def update_microsoft_event(
 async def delete_calendar_event(
     request: Request,
     event_id: str = Path(..., description="Event ID (format: provider_originalId)"),
-    service_name: str = Depends(ServicePermissionRequired(["write_calendar"])),
+    service_name: str = Depends(service_permission_required(["write_calendar"])),
 ) -> ApiResponse:
     """
     Delete a calendar event by ID.

--- a/services/office/api/files.py
+++ b/services/office/api/files.py
@@ -19,7 +19,7 @@ from services.common.http_errors import (
     ValidationError,
 )
 from services.office.core.api_client_factory import APIClientFactory
-from services.office.core.auth import ServicePermissionRequired
+from services.office.core.auth import service_permission_required
 from services.office.core.cache_manager import cache_manager, generate_cache_key
 from services.office.core.normalizer import (
     normalize_google_drive_file,
@@ -75,7 +75,7 @@ async def get_files(
     include_folders: bool = Query(
         True, description="Whether to include folders in results"
     ),
-    service_name: str = Depends(ServicePermissionRequired(["read_files"])),
+    service_name: str = Depends(service_permission_required(["read_files"])),
 ) -> ApiResponse:
     """
     Get unified files from multiple providers.
@@ -345,7 +345,7 @@ async def search_files(
     file_types: Optional[List[str]] = Query(
         None, description="Filter by file types/mime types"
     ),
-    service_name: str = Depends(ServicePermissionRequired(["read_files"])),
+    service_name: str = Depends(service_permission_required(["read_files"])),
 ) -> ApiResponse:
     """
     Search files across multiple providers.
@@ -559,7 +559,7 @@ async def get_file(
     include_download_url: bool = Query(
         False, description="Whether to include download URL"
     ),
-    service_name: str = Depends(ServicePermissionRequired(["read_files"])),
+    service_name: str = Depends(service_permission_required(["read_files"])),
 ) -> ApiResponse:
     """
     Get a specific file by ID.

--- a/services/office/core/auth.py
+++ b/services/office/core/auth.py
@@ -5,26 +5,22 @@ Provides granular permission-based API key authentication for service-to-service
 and frontend-to-service communication with the principle of least privilege.
 """
 
-from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from fastapi import Request
 
-from services.common.http_errors import AuthError, ServiceError
+from services.common.api_key_auth import (
+    APIKeyConfig,
+    build_api_key_mapping,
+    make_service_permission_required,
+    make_verify_service_authentication,
+    verify_api_key,
+)
+from services.common.http_errors import AuthError
 from services.common.logging_config import get_logger
 from services.office.core.settings import get_settings
 
 logger = get_logger(__name__)
-
-
-@dataclass(frozen=True)
-class APIKeyConfig:
-    """Configuration for an API key."""
-
-    client: str
-    service: str
-    permissions: List[str]
-    settings_key: str  # The key name in settings to look up the actual API key value
 
 
 # API Key configurations mapped by settings key names
@@ -56,240 +52,39 @@ API_KEY_CONFIGS: Dict[str, APIKeyConfig] = {
     ),
 }
 
+# Service-level permissions fallback (optional, for legacy support)
+SERVICE_PERMISSIONS = {
+    "office-service-access": [
+        "read_emails",
+        "send_emails",
+        "read_calendar",
+        "write_calendar",
+        "read_files",
+        "write_files",
+    ],
+}
 
-def _get_api_key_mapping() -> Dict[str, APIKeyConfig]:
-    """
-    Build a mapping from actual API key values to their configurations.
-
-    Returns:
-        Dictionary mapping actual API key values to APIKeyConfig objects
-    """
-    settings = get_settings()
-    api_key_mapping = {}
-
-    for config_name, config in API_KEY_CONFIGS.items():
-        # Get the actual API key value from settings
-        actual_key_value = getattr(settings, config.settings_key, None)
-        if actual_key_value:
-            api_key_mapping[actual_key_value] = config
-        else:
-            logger.warning(f"API key not found in settings: {config.settings_key}")
-
-    return api_key_mapping
+# FastAPI dependencies
+verify_service_authentication = make_verify_service_authentication(
+    API_KEY_CONFIGS, get_settings
+)
 
 
-def verify_api_key(api_key: str) -> Optional[str]:
-    """
-    Verify an API key and return the service name it's authorized for.
-
-    Args:
-        api_key: The API key to verify
-
-    Returns:
-        Service name if valid, None if invalid
-    """
-    if not api_key:
-        return None
-
-    api_key_mapping = _get_api_key_mapping()
-    key_config = api_key_mapping.get(api_key)
-    if not key_config:
-        return None
-
-    return key_config.service
-
-
-def get_client_from_api_key(api_key: str) -> Optional[str]:
-    """Get the client name from an API key."""
-    api_key_mapping = _get_api_key_mapping()
-    key_config = api_key_mapping.get(api_key)
-    return key_config.client if key_config else None
-
-
-def get_permissions_from_api_key(api_key: str) -> List[str]:
-    """Get the permissions for an API key."""
-    api_key_mapping = _get_api_key_mapping()
-    key_config = api_key_mapping.get(api_key)
-    return key_config.permissions if key_config else []
-
-
-def has_permission(api_key: str, required_permission: str) -> bool:
-    """Check if an API key has a specific permission."""
-    permissions = get_permissions_from_api_key(api_key)
-    return required_permission in permissions
-
-
-async def validate_service_permissions(
-    service_name: str,
-    required_permissions: Optional[List[str]] = None,
-    api_key: Optional[str] = None,
-) -> bool:
-    """
-    Validate that a service has the required permissions.
-
-    Args:
-        service_name: The authenticated service name
-        required_permissions: List of required permissions
-        api_key: The API key used (for granular permission checking)
-
-    Returns:
-        True if service has all required permissions, False otherwise
-    """
-    if not required_permissions:
-        return True
-
-    # If we have the API key, use granular permission checking
-    if api_key:
-        key_permissions = get_permissions_from_api_key(api_key)
-        return all(perm in key_permissions for perm in required_permissions)
-
-    # Fallback to service-level permissions
-    service_permissions = {
-        "office-service-access": [
-            "read_emails",
-            "send_emails",
-            "read_calendar",
-            "write_calendar",
-            "read_files",
-            "write_files",
-        ],
-    }
-
-    allowed_permissions = service_permissions.get(service_name, [])
-    return all(perm in allowed_permissions for perm in required_permissions)
-
-
-async def get_api_key_from_request(request: Request) -> Optional[str]:
-    """
-    Extract API key from request headers.
-
-    Supports multiple header formats:
-    - Authorization: Bearer <api_key>
-    - X-API-Key: <api_key>
-    - X-Service-Key: <api_key>
-
-    Args:
-        request: FastAPI request object
-
-    Returns:
-        API key if found, None otherwise
-    """
-    # Try X-API-Key header (preferred)
-    api_key = request.headers.get("X-API-Key")
-    if api_key:
-        return api_key
-
-    # Try Authorization header
-    authorization = request.headers.get("Authorization")
-    if authorization and authorization.startswith("Bearer "):
-        return authorization[7:]  # Remove "Bearer " prefix
-
-    # Try X-Service-Key header (legacy)
-    service_key = request.headers.get("X-Service-Key")
-    if service_key:
-        return service_key
-
-    return None
-
-
-async def verify_service_authentication(request: Request) -> str:
-    """
-    Verify service authentication via API key.
-
-    Args:
-        request: FastAPI request object
-
-    Returns:
-        Service name if authentication succeeds
-
-    Raises:
-        HTTPException: If authentication fails
-    """
-    api_key = await get_api_key_from_request(request)
-
-    if not api_key:
-        logger.warning("Missing API key in request headers")
-        raise AuthError(message="API key required", status_code=401)
-
-    service_name = verify_api_key(api_key)
-
-    if not service_name:
-        logger.warning(f"Invalid API key: {api_key[:8]}...")
-        raise AuthError(message="Invalid API key", status_code=401)
-
-    # Store API key and client info in request state for permission checking
-    request.state.api_key = api_key
-    request.state.service_name = service_name
-    request.state.client_name = get_client_from_api_key(api_key)
-
-    logger.info(
-        f"Service authenticated: {service_name} (client: {request.state.client_name})"
+def service_permission_required(
+    required_permissions: List[str],
+) -> Callable[[Request], Any]:
+    return make_service_permission_required(
+        required_permissions,
+        API_KEY_CONFIGS,
+        get_settings,
+        SERVICE_PERMISSIONS,
     )
-    return service_name
 
 
-class ServicePermissionRequired:
-    """
-    Dependency to check if the authenticated service has specific permissions.
-
-    Usage:
-        @app.post("/emails/send", dependencies=[Depends(ServicePermissionRequired(["send_emails"]))])
-        async def send_email():
-            # This endpoint requires send_emails permission
-            pass
-    """
-
-    def __init__(self, required_permissions: List[str]):
-        self.required_permissions = required_permissions
-
-    async def __call__(self, request: Request) -> str:
-        # First ensure service is authenticated
-        service_name = await verify_service_authentication(request)
-
-        # Check if the API key has the required permissions
-        api_key = getattr(request.state, "api_key", None)
-        if not api_key:
-            raise ServiceError(
-                message="API key not found in request state", status_code=500
-            )
-
-        # Validate permissions
-        if not await validate_service_permissions(
-            service_name, self.required_permissions, api_key
-        ):
-            client_name = getattr(request.state, "client_name", "unknown")
-            logger.warning(
-                f"Permission denied: {client_name} lacks permissions {self.required_permissions}",
-                extra={
-                    "service": service_name,
-                    "client": client_name,
-                    "required_permissions": self.required_permissions,
-                    "api_key_prefix": api_key[:8] if api_key else None,
-                },
-            )
-            raise AuthError(
-                message=f"Insufficient permissions. Required: {self.required_permissions}",
-                status_code=403,
-            )
-
-        return service_name
-
-
-async def optional_service_auth(request: Request) -> Optional[str]:
-    """
-    Optional service authentication that doesn't raise errors.
-
-    This can be used for endpoints that support both service-to-service
-    and direct user access.
-
-    Args:
-        request: FastAPI request object
-
-    Returns:
-        Service name if authenticated, None otherwise
-    """
+def optional_service_auth(request: Request) -> Optional[str]:
+    """Optional service authentication that returns None if no valid API key is provided."""
     try:
-        return await verify_service_authentication(request)
+        return verify_service_authentication(request)
     except AuthError:
         return None
 
@@ -305,7 +100,8 @@ class ServiceAPIKeyAuth:
 
     def verify_api_key(self, api_key: str) -> Optional[str]:
         """Legacy method - use verify_api_key function instead."""
-        return verify_api_key(api_key)
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        return verify_api_key(api_key, api_key_mapping)
 
     def is_valid_service(self, service_name: str) -> bool:
         """Legacy method - use validate_service_permissions function instead."""
@@ -314,3 +110,20 @@ class ServiceAPIKeyAuth:
 
 # Global service auth instance for backward compatibility
 service_auth = ServiceAPIKeyAuth()
+
+
+# Helper function for testing
+def get_test_api_keys() -> Dict[str, str]:
+    """Get test API keys for testing purposes."""
+    settings = get_settings()
+    return {
+        "frontend": settings.api_frontend_office_key,
+        "chat": settings.api_chat_office_key,
+    }
+
+
+# Helper function for testing
+def verify_api_key_for_testing(api_key: str) -> Optional[str]:
+    """Helper function for testing API key verification."""
+    api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+    return verify_api_key(api_key, api_key_mapping)

--- a/services/office/tests/test_auth.py
+++ b/services/office/tests/test_auth.py
@@ -5,22 +5,26 @@ Tests the granular API key authentication and permission system for the office s
 including API key validation, permission checking, and service authentication dependencies.
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
-from services.common.http_errors import AuthError, ServiceError
-from services.office.core.auth import (
-    ServicePermissionRequired,
+from services.common.api_key_auth import (
+    build_api_key_mapping,
     get_api_key_from_request,
     get_client_from_api_key,
     get_permissions_from_api_key,
     has_permission,
-    optional_service_auth,
     validate_service_permissions,
     verify_api_key,
+)
+from services.common.http_errors import AuthError
+from services.office.core.auth import (
+    API_KEY_CONFIGS,
+    optional_service_auth,
+    service_permission_required,
     verify_service_authentication,
 )
 from services.office.core.settings import get_settings
@@ -48,28 +52,26 @@ class TestAPIKeyFunctions:
 
     def test_verify_api_key_valid_frontend_key(self):
         """Test valid frontend API key verification."""
-        from services.office.core.settings import get_settings
-
-        settings = get_settings()
-        service_name = verify_api_key(settings.api_frontend_office_key)
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        service_name = verify_api_key(get_test_api_keys()["frontend"], api_key_mapping)
         assert service_name == "office-service-access"
 
     def test_verify_api_key_valid_chat_key(self):
         """Test valid chat service API key verification."""
-        from services.office.core.settings import get_settings
-
-        settings = get_settings()
-        service_name = verify_api_key(settings.api_chat_office_key)
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        service_name = verify_api_key(get_test_api_keys()["chat"], api_key_mapping)
         assert service_name == "office-service-access"
 
     def test_verify_api_key_invalid_key(self):
         """Test invalid API key verification."""
-        service_name = verify_api_key("invalid-key")
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        service_name = verify_api_key("invalid-key", api_key_mapping)
         assert service_name is None
 
     def test_verify_api_key_empty_key(self):
         """Test empty API key verification."""
-        service_name = verify_api_key("")
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        service_name = verify_api_key("", api_key_mapping)
         assert service_name is None
 
     def test_verify_api_key_none_key(self):
@@ -78,31 +80,37 @@ class TestAPIKeyFunctions:
 
     def test_get_client_from_api_key_frontend(self):
         """Test getting client name from frontend API key."""
-        from services.office.core.settings import get_settings
-
-        settings = get_settings()
-        client = get_client_from_api_key(settings.api_frontend_office_key)
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        request = Mock()
+        request.headers = {"X-API-Key": get_test_api_keys()["frontend"]}
+        api_key = get_api_key_from_request(request)
+        client = get_client_from_api_key(api_key, api_key_mapping)
         assert client == "frontend"
 
     def test_get_client_from_api_key_chat_service(self):
         """Test getting client name from chat service API key."""
-        from services.office.core.settings import get_settings
-
-        settings = get_settings()
-        client = get_client_from_api_key(settings.api_chat_office_key)
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        request = Mock()
+        request.headers = {"X-API-Key": get_test_api_keys()["chat"]}
+        api_key = get_api_key_from_request(request)
+        client = get_client_from_api_key(api_key, api_key_mapping)
         assert client == "chat-service"
 
     def test_get_client_from_api_key_invalid(self):
         """Test getting client name from invalid API key."""
-        client = get_client_from_api_key("invalid-key")
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        request = Mock()
+        request.headers = {"X-API-Key": "invalid-key"}
+        api_key = get_api_key_from_request(request)
+        client = get_client_from_api_key(api_key, api_key_mapping)
         assert client is None
 
     def test_get_permissions_from_api_key_frontend(self):
         """Test getting permissions from frontend API key."""
-        from services.office.core.settings import get_settings
-
-        settings = get_settings()
-        permissions = get_permissions_from_api_key(settings.api_frontend_office_key)
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        permissions = get_permissions_from_api_key(
+            get_test_api_keys()["frontend"], api_key_mapping
+        )
         expected = [
             "read_emails",
             "send_emails",
@@ -115,106 +123,122 @@ class TestAPIKeyFunctions:
 
     def test_get_permissions_from_api_key_chat_service(self):
         """Test getting permissions from chat service API key."""
-        from services.office.core.settings import get_settings
-
-        settings = get_settings()
-        permissions = get_permissions_from_api_key(settings.api_chat_office_key)
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        permissions = get_permissions_from_api_key(
+            get_test_api_keys()["chat"], api_key_mapping
+        )
         expected = ["read_emails", "read_calendar", "read_files"]
         assert permissions == expected
 
     def test_get_permissions_from_api_key_invalid(self):
         """Test getting permissions from invalid API key."""
-        permissions = get_permissions_from_api_key("invalid-key")
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        permissions = get_permissions_from_api_key("invalid-key", api_key_mapping)
         assert permissions == []
 
     def test_has_permission_frontend_send_emails(self):
         """Test frontend has send_emails permission."""
-        from services.office.core.settings import get_settings
-
-        settings = get_settings()
-        result = has_permission(settings.api_frontend_office_key, "send_emails")
-        assert result is True
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        assert (
+            has_permission(
+                get_test_api_keys()["frontend"], "send_emails", api_key_mapping
+            )
+            is True
+        )
 
     def test_has_permission_chat_service_no_send_emails(self):
         """Test chat service does not have send_emails permission."""
-        from services.office.core.settings import get_settings
-
-        settings = get_settings()
-        result = has_permission(settings.api_chat_office_key, "send_emails")
-        assert result is False
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        assert (
+            has_permission(get_test_api_keys()["chat"], "send_emails", api_key_mapping)
+            is False
+        )
 
     def test_has_permission_chat_service_read_emails(self):
         """Test chat service has read_emails permission."""
-        from services.office.core.settings import get_settings
-
-        settings = get_settings()
-        result = has_permission(settings.api_chat_office_key, "read_emails")
-        assert result is True
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        assert (
+            has_permission(get_test_api_keys()["chat"], "read_emails", api_key_mapping)
+            is True
+        )
 
     def test_has_permission_invalid_key(self):
-        # Should return False for invalid or empty key
-        assert has_permission("", "read_emails") is False
-        assert has_permission("invalid-key", "read_emails") is False
+        """Test that invalid key has no permissions."""
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        assert has_permission("invalid-key", "read_emails", api_key_mapping) is False
 
 
 class TestServicePermissionValidation:
     """Test service permission validation logic."""
 
-    @pytest.mark.asyncio
-    async def test_validate_service_permissions_with_api_key_success(self):
+    def test_validate_service_permissions_with_api_key_success(self):
         """Test successful permission validation with API key."""
         api_keys = get_test_api_keys()
-        result = await validate_service_permissions(
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        result = validate_service_permissions(
             "office-service-access",
-            ["read_emails", "send_emails"],
+            ["read_emails"],
             api_keys["frontend"],
+            api_key_mapping,
         )
         assert result is True
 
-    @pytest.mark.asyncio
-    async def test_validate_service_permissions_with_api_key_failure(self):
+    def test_validate_service_permissions_with_api_key_failure(self):
         """Test failed permission validation with API key."""
         api_keys = get_test_api_keys()
-        result = await validate_service_permissions(
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        result = validate_service_permissions(
             "office-service-access",
             ["send_emails"],
-            api_keys["chat"],  # Chat service can't send emails
+            api_keys["chat"],
+            api_key_mapping,
         )
         assert result is False
 
-    @pytest.mark.asyncio
-    async def test_validate_service_permissions_no_requirements(self):
+    def test_validate_service_permissions_no_requirements(self):
         """Test permission validation with no requirements."""
         api_keys = get_test_api_keys()
-        result = await validate_service_permissions(
-            "office-service-access", None, api_keys["chat"]
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        result = validate_service_permissions(
+            "office-service-access", None, api_keys["chat"], api_key_mapping
         )
         assert result is True
 
-    @pytest.mark.asyncio
-    async def test_validate_service_permissions_empty_requirements(self):
+    def test_validate_service_permissions_empty_requirements(self):
         """Test permission validation with empty requirements."""
         api_keys = get_test_api_keys()
-        result = await validate_service_permissions(
-            "office-service-access", [], api_keys["chat"]
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        result = validate_service_permissions(
+            "office-service-access", [], api_keys["chat"], api_key_mapping
         )
         assert result is True
 
-    @pytest.mark.asyncio
-    async def test_validate_service_permissions_fallback_service_level(self):
+    def test_validate_service_permissions_fallback_service_level(self):
         """Test permission validation fallback to service level."""
-        result = await validate_service_permissions(
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        # Define service permissions for the fallback test
+        service_permissions = {
+            "office-service-access": [
+                "read_emails",
+                "send_emails",
+                "read_calendar",
+                "write_calendar",
+            ]
+        }
+        result = validate_service_permissions(
             "office-service-access",
             ["read_emails"],
-            None,  # No API key, use service-level fallback
+            None,
+            api_key_mapping,
+            service_permissions,
         )
         assert result is True
 
-    @pytest.mark.asyncio
-    async def test_validate_service_permissions_fallback_invalid_permission(self):
+    def test_validate_service_permissions_fallback_invalid_permission(self):
         """Test permission validation fallback with invalid permission."""
-        result = await validate_service_permissions(
-            "office-service-access", ["invalid_permission"], None
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        result = validate_service_permissions(
+            "office-service-access", ["invalid_permission"], None, api_key_mapping
         )
         assert result is False
 
@@ -228,7 +252,7 @@ class TestAPIKeyExtraction:
         request = Mock()
         request.headers = {"X-API-Key": "test-api-key"}
 
-        api_key = await get_api_key_from_request(request)
+        api_key = get_api_key_from_request(request)
         assert api_key == "test-api-key"
 
     @pytest.mark.asyncio
@@ -237,7 +261,7 @@ class TestAPIKeyExtraction:
         request = Mock()
         request.headers = {"Authorization": "Bearer test-api-key"}
 
-        api_key = await get_api_key_from_request(request)
+        api_key = get_api_key_from_request(request)
         assert api_key == "test-api-key"
 
     @pytest.mark.asyncio
@@ -246,7 +270,7 @@ class TestAPIKeyExtraction:
         request = Mock()
         request.headers = {"X-Service-Key": "test-api-key"}
 
-        api_key = await get_api_key_from_request(request)
+        api_key = get_api_key_from_request(request)
         assert api_key == "test-api-key"
 
     @pytest.mark.asyncio
@@ -259,7 +283,7 @@ class TestAPIKeyExtraction:
             "X-Service-Key": "another-key",
         }
 
-        api_key = await get_api_key_from_request(request)
+        api_key = get_api_key_from_request(request)
         assert api_key == "preferred-key"
 
     @pytest.mark.asyncio
@@ -268,7 +292,7 @@ class TestAPIKeyExtraction:
         request = Mock()
         request.headers = {}
 
-        api_key = await get_api_key_from_request(request)
+        api_key = get_api_key_from_request(request)
         assert api_key is None
 
     @pytest.mark.asyncio
@@ -277,67 +301,62 @@ class TestAPIKeyExtraction:
         request = Mock()
         request.headers = {"Authorization": "Basic invalid-format"}
 
-        api_key = await get_api_key_from_request(request)
+        api_key = get_api_key_from_request(request)
         assert api_key is None
 
 
 class TestServiceAuthentication:
     """Test service authentication workflow."""
 
-    @pytest.mark.asyncio
-    async def test_verify_service_authentication_success(self):
+    def test_verify_service_authentication_success(self):
         """Test successful service authentication."""
         request = Mock()
         request.headers = {"X-API-Key": get_test_api_keys()["frontend"]}
         request.state = Mock()
 
-        service_name = await verify_service_authentication(request)
+        service_name = verify_service_authentication(request)
         assert service_name == "office-service-access"
         assert request.state.api_key == get_test_api_keys()["frontend"]
         assert request.state.service_name == "office-service-access"
         assert request.state.client_name == "frontend"
 
-    @pytest.mark.asyncio
-    async def test_verify_service_authentication_missing_api_key(self):
+    def test_verify_service_authentication_missing_api_key(self):
         """Test service authentication with missing API key."""
         request = Mock()
         request.headers = {}
 
         with pytest.raises(AuthError) as exc_info:
-            await verify_service_authentication(request)
+            verify_service_authentication(request)
 
         assert exc_info.value.status_code == 401
         assert "API key required" in str(exc_info.value)
 
-    @pytest.mark.asyncio
-    async def test_verify_service_authentication_invalid_api_key(self):
+    def test_verify_service_authentication_invalid_api_key(self):
         """Test service authentication with invalid API key."""
         request = Mock()
         request.headers = {"X-API-Key": "invalid-key"}
 
         with pytest.raises(AuthError) as exc_info:
-            await verify_service_authentication(request)
+            verify_service_authentication(request)
 
         assert exc_info.value.status_code == 401
         assert "Invalid API key" in str(exc_info.value)
 
-    @pytest.mark.asyncio
-    async def test_optional_service_auth_success(self):
+    def test_optional_service_auth_success(self):
         """Test optional service authentication success."""
         request = Mock()
         request.headers = {"X-API-Key": get_test_api_keys()["frontend"]}
         request.state = Mock()
 
-        service_name = await optional_service_auth(request)
+        service_name = optional_service_auth(request)
         assert service_name == "office-service-access"
 
-    @pytest.mark.asyncio
-    async def test_optional_service_auth_failure(self):
+    def test_optional_service_auth_failure(self):
         """Test optional service authentication failure."""
         request = Mock()
         request.headers = {}
 
-        service_name = await optional_service_auth(request)
+        service_name = optional_service_auth(request)
         assert service_name is None
 
 
@@ -351,7 +370,7 @@ class TestServicePermissionRequired:
         request.headers = {"X-API-Key": get_test_api_keys()["frontend"]}
         request.state = Mock()
 
-        permission_check = ServicePermissionRequired(["send_emails"])
+        permission_check = service_permission_required(["send_emails"])
         service_name = await permission_check(request)
 
         assert service_name == "office-service-access"
@@ -365,7 +384,7 @@ class TestServicePermissionRequired:
         }  # Can't send emails
         request.state = Mock()
 
-        permission_check = ServicePermissionRequired(["send_emails"])
+        permission_check = service_permission_required(["send_emails"])
 
         with pytest.raises(AuthError) as exc_info:
             await permission_check(request)
@@ -380,31 +399,27 @@ class TestServicePermissionRequired:
         request.headers = {"X-API-Key": get_test_api_keys()["frontend"]}
         request.state = Mock()
 
-        permission_check = ServicePermissionRequired(["read_emails", "send_emails"])
+        permission_check = service_permission_required(["read_emails", "send_emails"])
         service_name = await permission_check(request)
 
         assert service_name == "office-service-access"
 
     @pytest.mark.asyncio
     async def test_service_permission_required_missing_api_key_state(self):
-        """Test permission check with missing API key in state."""
-        # Mock the authentication to pass but not set api_key in state
+        """Test permission check with invalid API key."""
+        # Create a request with an invalid API key
         request = Mock()
         request.state = Mock()
-        request.state.api_key = None  # Missing API key
+        request.headers = {"Authorization": "Bearer invalid-key"}
 
-        permission_check = ServicePermissionRequired(["read_emails"])
+        permission_check = service_permission_required(["read_emails"])
 
-        with patch(
-            "services.office.core.auth.verify_service_authentication"
-        ) as mock_auth:
-            mock_auth.return_value = "office-service-access"
+        # The test should fail because the API key is invalid
+        with pytest.raises(AuthError) as exc_info:
+            await permission_check(request)
 
-            with pytest.raises(ServiceError) as exc_info:
-                await permission_check(request)
-
-            assert exc_info.value.status_code == 500
-            assert "API key not found in request state" in str(exc_info.value)
+        assert exc_info.value.status_code == 401
+        assert "Invalid API key" in str(exc_info.value)
 
 
 class TestIntegrationWithFastAPI:
@@ -416,7 +431,7 @@ class TestIntegrationWithFastAPI:
 
         @app.post("/emails/send")
         async def send_email(
-            service_name: str = Depends(ServicePermissionRequired(["send_emails"])),
+            service_name: str = Depends(service_permission_required(["send_emails"])),
         ):
             return {"status": "sent", "service": service_name}
 
@@ -447,7 +462,7 @@ class TestIntegrationWithFastAPI:
 
         @app.get("/emails")
         async def get_emails(
-            service_name: str = Depends(ServicePermissionRequired(["read_emails"])),
+            service_name: str = Depends(service_permission_required(["read_emails"])),
         ):
             return {"emails": [], "service": service_name}
 
@@ -471,7 +486,7 @@ class TestIntegrationWithFastAPI:
 
         @app.get("/protected")
         async def protected_endpoint(
-            service_name: str = Depends(ServicePermissionRequired(["read_emails"])),
+            service_name: str = Depends(service_permission_required(["read_emails"])),
         ):
             return {"service": service_name}
 
@@ -492,7 +507,7 @@ class TestIntegrationWithFastAPI:
 
         @app.get("/protected")
         async def protected_endpoint(
-            service_name: str = Depends(ServicePermissionRequired(["read_emails"])),
+            service_name: str = Depends(service_permission_required(["read_emails"])),
         ):
             return {"service": service_name}
 
@@ -513,7 +528,10 @@ class TestPermissionMatrix:
 
     def test_frontend_permissions_complete(self):
         """Test that frontend key has all expected permissions."""
-        permissions = get_permissions_from_api_key(get_test_api_keys()["frontend"])
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        permissions = get_permissions_from_api_key(
+            get_test_api_keys()["frontend"], api_key_mapping
+        )
         expected = [
             "read_emails",
             "send_emails",
@@ -530,7 +548,10 @@ class TestPermissionMatrix:
 
     def test_chat_service_permissions_read_only(self):
         """Test that chat service key has only read permissions."""
-        permissions = get_permissions_from_api_key(get_test_api_keys()["chat"])
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
+        permissions = get_permissions_from_api_key(
+            get_test_api_keys()["chat"], api_key_mapping
+        )
 
         # Should have read permissions
         assert "read_emails" in permissions
@@ -548,43 +569,82 @@ class TestSecurityScenarios:
 
     def test_email_sending_security(self):
         """Test that only authorized clients can send emails."""
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
         # Frontend can send
-        assert has_permission(get_test_api_keys()["frontend"], "send_emails") is True
+        assert (
+            has_permission(
+                get_test_api_keys()["frontend"], "send_emails", api_key_mapping
+            )
+            is True
+        )
 
         # Chat service cannot send
-        assert has_permission(get_test_api_keys()["chat"], "send_emails") is False
+        assert (
+            has_permission(get_test_api_keys()["chat"], "send_emails", api_key_mapping)
+            is False
+        )
 
     def test_calendar_writing_security(self):
         """Test that only authorized clients can write to calendar."""
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
         # Frontend can write
-        assert has_permission(get_test_api_keys()["frontend"], "write_calendar") is True
+        assert (
+            has_permission(
+                get_test_api_keys()["frontend"], "write_calendar", api_key_mapping
+            )
+            is True
+        )
 
         # Chat service cannot write
-        assert has_permission(get_test_api_keys()["chat"], "write_calendar") is False
+        assert (
+            has_permission(
+                get_test_api_keys()["chat"], "write_calendar", api_key_mapping
+            )
+            is False
+        )
 
     def test_file_access_security(self):
         """Test file access permissions."""
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
         # Frontend can read and write
-        assert has_permission(get_test_api_keys()["frontend"], "read_files") is True
-        assert has_permission(get_test_api_keys()["frontend"], "write_files") is True
+        assert (
+            has_permission(
+                get_test_api_keys()["frontend"], "read_files", api_key_mapping
+            )
+            is True
+        )
+        assert (
+            has_permission(
+                get_test_api_keys()["frontend"], "write_files", api_key_mapping
+            )
+            is True
+        )
 
         # Chat service can only read
-        assert has_permission(get_test_api_keys()["chat"], "read_files") is True
-        assert has_permission(get_test_api_keys()["chat"], "write_files") is False
+        assert (
+            has_permission(get_test_api_keys()["chat"], "read_files", api_key_mapping)
+            is True
+        )
+        assert (
+            has_permission(get_test_api_keys()["chat"], "write_files", api_key_mapping)
+            is False
+        )
 
-    @pytest.mark.asyncio
-    async def test_privilege_escalation_prevention(self):
+    def test_privilege_escalation_prevention(self):
         """Test that services cannot escalate privileges."""
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
         # Chat service should not be able to perform write operations
-        result = await validate_service_permissions(
+        result = validate_service_permissions(
             "office-service-access",
-            ["send_emails", "write_calendar"],
+            ["send_emails", "write_calendar", "write_files"],
             get_test_api_keys()["chat"],
+            api_key_mapping,
         )
         assert result is False
 
     def test_api_key_enumeration_protection(self):
         """Test protection against API key enumeration."""
+        api_key_mapping = build_api_key_mapping(API_KEY_CONFIGS, get_settings)
         # Various invalid keys should all return None
         invalid_keys = [
             "api-frontend-invalid-key",
@@ -595,6 +655,6 @@ class TestSecurityScenarios:
         ]
 
         for key in invalid_keys:
-            assert verify_api_key(key) is None
-            assert get_client_from_api_key(key) is None
-            assert get_permissions_from_api_key(key) == []
+            assert verify_api_key(key, api_key_mapping) is None
+            assert get_client_from_api_key(key, api_key_mapping) is None
+            assert get_permissions_from_api_key(key, api_key_mapping) == []


### PR DESCRIPTION
- Centralize API key authentication and permission logic in services/common/api_key_auth.py
- Add make_verify_service_authentication and make_service_permission_required for FastAPI dependency injection
- Improve logging and error handling for missing/invalid API keys and insufficient permissions
- Support flexible permission validation for both API keys and service-level permissions
- Update request state to include api_key, service_name, and client_name for downstream use