### PR TITLE
feat(shipments): add shared API key authentication and permission logic

### DIFF
--- a/services/shipments/routers/packages.py
+++ b/services/shipments/routers/packages.py
@@ -13,12 +13,16 @@ from services.shipments.schemas import (
     PackageOut,
     PackageUpdate,
 )
+from services.shipments.service_auth import service_permission_required
 
 router = APIRouter()
 
 
 @router.get("/", response_model=PackageListResponse)
-async def list_packages(session: AsyncSession = Depends(get_async_session_dep)) -> dict:
+async def list_packages(
+    session: AsyncSession = Depends(get_async_session_dep),
+    service_name: str = Depends(service_permission_required(["read_shipments"])),
+) -> dict:
     logging.info("Fetching all packages from DB...")
     result = await session.execute(select(Package))
     packages = result.scalars().all()
@@ -51,7 +55,9 @@ async def list_packages(session: AsyncSession = Depends(get_async_session_dep)) 
 
 @router.post("/", response_model=PackageOut)
 async def add_package(
-    pkg: PackageCreate, session: AsyncSession = Depends(get_async_session_dep)
+    pkg: PackageCreate,
+    session: AsyncSession = Depends(get_async_session_dep),
+    service_name: str = Depends(service_permission_required(["write_shipments"])),
 ) -> PackageOut:
     db_pkg = Package(**pkg.dict())
     session.add(db_pkg)
@@ -77,7 +83,9 @@ async def add_package(
 
 @router.get("/{id}", response_model=PackageOut)
 async def get_package(
-    id: int, session: AsyncSession = Depends(get_async_session_dep)
+    id: int,
+    session: AsyncSession = Depends(get_async_session_dep),
+    service_name: str = Depends(service_permission_required(["read_shipments"])),
 ) -> PackageOut:
     # TODO: Implement get package details
     # For now, return a dummy response
@@ -101,7 +109,10 @@ async def get_package(
 
 @router.put("/{id}", response_model=PackageOut)
 async def update_package(
-    id: int, pkg: PackageUpdate, session: AsyncSession = Depends(get_async_session_dep)
+    id: int,
+    pkg: PackageUpdate,
+    session: AsyncSession = Depends(get_async_session_dep),
+    service_name: str = Depends(service_permission_required(["write_shipments"])),
 ) -> PackageOut:
     # TODO: Implement update package
     return PackageOut(
@@ -124,7 +135,9 @@ async def update_package(
 
 @router.delete("/{id}")
 async def delete_package(
-    id: int, session: AsyncSession = Depends(get_async_session_dep)
+    id: int,
+    session: AsyncSession = Depends(get_async_session_dep),
+    service_name: str = Depends(service_permission_required(["write_shipments"])),
 ) -> dict:
     # TODO: Implement delete package
     return {"success": True}
@@ -132,7 +145,9 @@ async def delete_package(
 
 @router.post("/{id}/refresh")
 async def refresh_package(
-    id: int, session: AsyncSession = Depends(get_async_session_dep)
+    id: int,
+    session: AsyncSession = Depends(get_async_session_dep),
+    service_name: str = Depends(service_permission_required(["write_shipments"])),
 ) -> dict:
     # TODO: Implement force refresh tracking
     return {"success": True}
@@ -140,7 +155,9 @@ async def refresh_package(
 
 @router.post("/{id}/labels")
 async def add_label_to_package(
-    id: int, session: AsyncSession = Depends(get_async_session_dep)
+    id: int,
+    session: AsyncSession = Depends(get_async_session_dep),
+    service_name: str = Depends(service_permission_required(["write_shipments"])),
 ) -> dict:
     # TODO: Implement add label to package
     return {"success": True}
@@ -148,7 +165,10 @@ async def add_label_to_package(
 
 @router.delete("/{id}/labels/{label_id}")
 async def remove_label_from_package(
-    id: int, label_id: int, session: AsyncSession = Depends(get_async_session_dep)
+    id: int,
+    label_id: int,
+    session: AsyncSession = Depends(get_async_session_dep),
+    service_name: str = Depends(service_permission_required(["write_shipments"])),
 ) -> dict:
     # TODO: Implement remove label from package
     return {"success": True}

--- a/services/shipments/service_auth.py
+++ b/services/shipments/service_auth.py
@@ -1,0 +1,88 @@
+from typing import Any, Callable, Dict, List
+
+from fastapi import Request
+
+from services.common.api_key_auth import (
+    APIKeyConfig,
+)
+from services.common.api_key_auth import (
+    client_has_permission as shared_client_has_permission,
+)
+from services.common.api_key_auth import (
+    get_client_permissions as shared_get_client_permissions,
+)
+from services.common.api_key_auth import (
+    make_service_permission_required,
+    make_verify_service_authentication,
+)
+from services.shipments.settings import get_settings
+
+# API Key configurations mapped by settings key names
+API_KEY_CONFIGS: Dict[str, APIKeyConfig] = {
+    "api_frontend_shipments_key": APIKeyConfig(
+        client="frontend",
+        service="shipments-service-access",
+        permissions=[
+            "read_shipments",
+            "write_shipments",
+            "read_labels",
+            "write_labels",
+        ],
+        settings_key="api_frontend_shipments_key",
+    ),
+}
+
+# Service-level permissions fallback (optional, for legacy support)
+SERVICE_PERMISSIONS = {
+    "shipments-service-access": [
+        "read_shipments",
+        "write_shipments",
+        "read_labels",
+        "write_labels",
+    ],
+}
+
+# FastAPI dependencies
+verify_service_authentication = make_verify_service_authentication(
+    API_KEY_CONFIGS, get_settings
+)
+
+
+def service_permission_required(
+    required_permissions: List[str],
+) -> Callable[[Request], Any]:
+    return make_service_permission_required(
+        required_permissions,
+        API_KEY_CONFIGS,
+        get_settings,
+        SERVICE_PERMISSIONS,
+    )
+
+
+def get_client_permissions(client_name: str) -> list[str]:
+    return shared_get_client_permissions(
+        client_name,
+        {
+            "frontend": [
+                "read_shipments",
+                "write_shipments",
+                "read_labels",
+                "write_labels",
+            ],
+        },
+    )
+
+
+def client_has_permission(client_name: str, required_permission: str) -> bool:
+    return shared_client_has_permission(
+        client_name,
+        required_permission,
+        {
+            "frontend": [
+                "read_shipments",
+                "write_shipments",
+                "read_labels",
+                "write_labels",
+            ],
+        },
+    )

--- a/services/shipments/test_service_auth.py
+++ b/services/shipments/test_service_auth.py
@@ -1,0 +1,87 @@
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from fastapi import Request
+
+import services.shipments.settings
+from services.shipments.service_auth import (
+    client_has_permission,
+    get_client_permissions,
+    service_permission_required,
+    verify_service_authentication,
+)
+
+
+@pytest.fixture(autouse=True)
+def setup_service_auth():
+    """Set up service auth with test API key by patching the settings singleton."""
+    test_settings = services.shipments.settings.Settings(
+        db_url_shipments="sqlite:///:memory:"
+    )
+    test_settings.api_frontend_shipments_key = "test-api-key"
+    services.shipments.settings._settings = test_settings
+    yield
+    services.shipments.settings._settings = None
+
+
+def test_get_client_permissions():
+    perms = get_client_permissions("frontend")
+    expected = [
+        "read_shipments",
+        "write_shipments",
+        "read_labels",
+        "write_labels",
+    ]
+    assert perms == expected
+
+
+def test_client_has_permission():
+    assert client_has_permission("frontend", "read_shipments") is True
+    assert client_has_permission("frontend", "write_labels") is True
+    assert client_has_permission("frontend", "not_a_permission") is False
+    assert client_has_permission("invalid-client", "read_shipments") is False
+
+
+@pytest.mark.asyncio
+def test_verify_service_authentication_success():
+    request = MagicMock(spec=Request)
+    request.headers = {"Authorization": "Bearer test-api-key"}
+    request.state = Mock()
+    service_name = verify_service_authentication(request)
+    assert service_name == "shipments-service-access"
+
+
+@pytest.mark.asyncio
+def test_verify_service_authentication_invalid_key():
+    request = MagicMock(spec=Request)
+    request.headers = {"Authorization": "Bearer invalid-key"}
+    request.state = Mock()
+    with pytest.raises(Exception):
+        verify_service_authentication(request)
+
+
+@pytest.mark.asyncio
+def test_service_permission_required_success():
+    request = MagicMock(spec=Request)
+    request.headers = {"Authorization": "Bearer test-api-key"}
+    request.state = Mock()
+    dep = service_permission_required(["read_shipments"])
+    service_name = (
+        pytest.run(dep(request))
+        if hasattr(pytest, "run")
+        else pytest.asyncio.run(dep(request))
+    )
+    assert service_name == "shipments-service-access"
+
+
+@pytest.mark.asyncio
+def test_service_permission_required_failure():
+    request = MagicMock(spec=Request)
+    request.headers = {"Authorization": "Bearer test-api-key"}
+    request.state = Mock()
+    dep = service_permission_required(["not_a_permission"])
+    with pytest.raises(Exception):
+        if hasattr(pytest, "run"):
+            pytest.run(dep(request))
+        else:
+            pytest.asyncio.run(dep(request))


### PR DESCRIPTION
- Implement shared API key authentication and permission logic in `services/shipments/service_auth.py` using the common helpers.
- Add permission-based FastAPI dependencies to all endpoints in `routers/packages.py` (read/write separation).
- Add `test_service_auth.py` with tests for API key authentication and permission logic, patching the settings singleton for robust test isolation.
- Follows the refactor get_settings pattern from user, office, and chat services for consistency and security.