### PR TITLE
feat(office): add shared API key authentication and permission logic

### DIFF
--- a/services/common/test_utils.py
+++ b/services/common/test_utils.py
@@ -11,8 +11,6 @@ from unittest.mock import MagicMock, patch
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from services.office.core.settings import get_settings
-
 
 class BaseIntegrationTest:
     """Base class for integration tests with HTTP call detection rakes."""
@@ -165,6 +163,9 @@ class BaseOfficeServiceIntegrationTest(BaseIntegrationTest):
         self.client = self.create_test_client(app)
 
         # Set up default auth headers for tests
+        # Import settings here to avoid module-level dependency
+        from services.office.core.settings import get_settings
+
         settings = get_settings()
         self.auth_headers = {
             "X-User-Id": "test-user@example.com",

--- a/services/common/test_utils.py
+++ b/services/common/test_utils.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from services.office.core.settings import get_settings
+
 
 class BaseIntegrationTest:
     """Base class for integration tests with HTTP call detection rakes."""
@@ -163,7 +165,11 @@ class BaseOfficeServiceIntegrationTest(BaseIntegrationTest):
         self.client = self.create_test_client(app)
 
         # Set up default auth headers for tests
-        self.auth_headers = {"X-User-Id": "test-user@example.com"}
+        settings = get_settings()
+        self.auth_headers = {
+            "X-User-Id": "test-user@example.com",
+            "Authorization": f"Bearer {settings.api_frontend_office_key}",
+        }
 
     def teardown_method(self, method: object) -> None:
         """Clean up Office Service specific patches."""

--- a/services/office/api/email.py
+++ b/services/office/api/email.py
@@ -12,10 +12,11 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, cast
 
-from fastapi import APIRouter, Path, Query, Request
+from fastapi import APIRouter, Depends, Path, Query, Request
 
 from services.common.http_errors import NotFoundError, ServiceError, ValidationError
 from services.office.core.api_client_factory import APIClientFactory
+from services.office.core.auth import service_permission_required
 from services.office.core.cache_manager import cache_manager, generate_cache_key
 from services.office.core.clients.google import GoogleAPIClient
 from services.office.core.clients.microsoft import MicrosoftAPIClient
@@ -56,6 +57,7 @@ async def get_user_id_from_gateway(request: Request) -> str:
 @router.get("/messages", response_model=EmailMessageList)
 async def get_email_messages(
     request: Request,
+    service_name: str = Depends(service_permission_required(["read_emails"])),
     providers: Optional[List[str]] = Query(
         None,
         description="Providers to fetch from (google, microsoft). If not specified, fetches from all available providers",
@@ -242,6 +244,7 @@ async def get_email_messages(
 @router.get("/messages/{message_id}", response_model=EmailMessageList)
 async def get_email_message(
     request: Request,
+    service_name: str = Depends(service_permission_required(["read_emails"])),
     message_id: str = Path(..., description="Message ID (format: provider_originalId)"),
     include_body: bool = Query(
         True, description="Whether to include message body content"
@@ -338,6 +341,7 @@ async def get_email_message(
 async def send_email(
     request: Request,
     email_data: SendEmailRequest,
+    service_name: str = Depends(service_permission_required(["send_emails"])),
 ) -> SendEmailResponse:
     """
     Send an email through a specific provider.

--- a/services/office/api/health.py
+++ b/services/office/api/health.py
@@ -10,10 +10,11 @@ from datetime import datetime, timezone
 from typing import Any, Dict
 
 import httpx
-from fastapi import APIRouter, Path, Response
+from fastapi import APIRouter, Depends, Path, Response
 from fastapi.responses import JSONResponse
 from sqlmodel import select
 
+from services.office.core.auth import service_permission_required
 from services.office.core.cache_manager import cache_manager
 from services.office.core.settings import get_settings
 from services.office.core.token_manager import TokenManager
@@ -29,7 +30,9 @@ token_manager = TokenManager()
 
 
 @router.get("/")
-async def health_check() -> Response:
+async def health_check(
+    service_name: str = Depends(service_permission_required(["health"])),
+) -> Response:
     """
     Comprehensive health check endpoint.
 
@@ -95,7 +98,8 @@ async def health_check() -> Response:
 
 @router.get("/integrations/{user_id}")
 async def integration_health_check(
-    user_id: str = Path(..., description="ID of the user to check integrations for")
+    user_id: str = Path(..., description="ID of the user to check integrations for"),
+    service_name: str = Depends(service_permission_required(["health"])),
 ) -> Response:
     """
     Check the health of external integrations for a specific user.
@@ -289,7 +293,9 @@ async def check_user_integration(user_id: str, provider: str) -> Dict[str, Any]:
 
 
 @router.get("/quick")
-async def quick_health_check() -> Dict[str, Any]:
+async def quick_health_check(
+    service_name: str = Depends(service_permission_required(["health"])),
+) -> Dict[str, Any]:
     """
     Quick health check endpoint for load balancers and basic monitoring.
 

--- a/services/office/api/health.py
+++ b/services/office/api/health.py
@@ -18,7 +18,7 @@ from services.office.core.auth import service_permission_required
 from services.office.core.cache_manager import cache_manager
 from services.office.core.settings import get_settings
 from services.office.core.token_manager import TokenManager
-from services.office.models import ApiCall, async_session
+from services.office.models import ApiCall, get_async_session_factory
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +172,8 @@ async def check_database_health() -> bool:
     """Check if the database connection is healthy."""
     try:
         # Test database connection by executing a simple query
-        async with async_session() as session:
+        async_session_factory = get_async_session_factory()
+        async with async_session_factory() as session:
             await session.execute(select(ApiCall).limit(1))
             logger.debug("Database health check passed")
             return True

--- a/services/office/app/main.py
+++ b/services/office/app/main.py
@@ -18,13 +18,7 @@ from services.office.api.files import router as files_router
 from services.office.api.health import router as health_router
 from services.office.core.settings import get_settings
 
-# Set up centralized logging
-settings = get_settings()
-setup_service_logging(
-    service_name="office-service",
-    log_level=settings.LOG_LEVEL,
-    log_format=settings.LOG_FORMAT,
-)
+# Set up centralized logging - will be initialized in lifespan
 
 logger = get_logger(__name__)
 
@@ -33,6 +27,14 @@ logger = get_logger(__name__)
 async def lifespan(app: FastAPI) -> AsyncGenerator:
     # Startup event logic
     settings = get_settings()
+
+    # Set up centralized logging
+    setup_service_logging(
+        service_name="office-service",
+        log_level=settings.LOG_LEVEL,
+        log_format=settings.LOG_FORMAT,
+    )
+
     log_service_startup(
         "office-service",
         app_name=settings.APP_NAME,
@@ -47,10 +49,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
 
 
 app = FastAPI(
-    title=get_settings().APP_NAME,
+    title="Office Service",
     description="A backend microservice responsible for all external API interactions with Google and Microsoft services",
-    version=get_settings().APP_VERSION,
-    debug=get_settings().DEBUG,
+    version="0.1.0",
+    debug=False,
     lifespan=lifespan,
 )
 
@@ -81,7 +83,7 @@ async def ready_check() -> Dict[str, str]:
     """
     return {
         "status": "ok",
-        "service": get_settings().APP_NAME,
-        "version": get_settings().APP_VERSION,
+        "service": "Office Service",
+        "version": "0.1.0",
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }

--- a/services/office/core/auth.py
+++ b/services/office/core/auth.py
@@ -36,6 +36,7 @@ API_KEY_CONFIGS: Dict[str, APIKeyConfig] = {
             "write_calendar",
             "read_files",
             "write_files",
+            "health",
         ],
         settings_key="api_frontend_office_key",
     ),
@@ -47,6 +48,7 @@ API_KEY_CONFIGS: Dict[str, APIKeyConfig] = {
             "read_emails",
             "read_calendar",
             "read_files",
+            "health",
         ],  # No write permissions
         settings_key="api_chat_office_key",
     ),
@@ -61,6 +63,7 @@ SERVICE_PERMISSIONS = {
         "write_calendar",
         "read_files",
         "write_files",
+        "health",
     ],
 }
 

--- a/services/office/core/settings.py
+++ b/services/office/core/settings.py
@@ -33,11 +33,11 @@ class Settings(BaseSettings):
 
     # API Keys for service communication
     api_frontend_office_key: str = Field(
-        default="default-office-key",
+        ...,  # Required field - no default to prevent production mistakes
         description="Frontend API key to access this Office service",
     )
     api_chat_office_key: str = Field(
-        default="default-chat-office-key",
+        ...,  # Required field - no default to prevent production mistakes
         description="Chat service API key to access this Office service",
     )
     api_office_user_key: Optional[str] = Field(

--- a/services/office/models/__init__.py
+++ b/services/office/models/__init__.py
@@ -16,7 +16,7 @@ _engine = None
 _async_session = None
 
 
-def get_engine():
+def get_engine() -> Any:
     """Get database engine with lazy initialization."""
     global _engine
     if _engine is None:
@@ -26,7 +26,7 @@ def get_engine():
     return _engine
 
 
-def get_async_session_factory():
+def get_async_session_factory() -> Any:
     """Get async session factory with lazy initialization."""
     global _async_session
     if _async_session is None:

--- a/services/office/models/__init__.py
+++ b/services/office/models/__init__.py
@@ -11,17 +11,32 @@ from sqlmodel import Column, DateTime, Field, SQLModel
 from services.common import get_async_database_url
 from services.office.core.settings import get_settings
 
-engine = create_async_engine(
-    get_async_database_url(get_settings().db_url_office),
-    echo=False,
-)
+# Global variables for lazy initialization
+_engine = None
+_async_session = None
 
-# Session factory for dependency injection
-async_session = async_sessionmaker(
-    engine,
-    class_=AsyncSession,
-    expire_on_commit=False,
-)
+
+def get_engine():
+    """Get database engine with lazy initialization."""
+    global _engine
+    if _engine is None:
+        settings = get_settings()
+        database_url = get_async_database_url(settings.db_url_office)
+        _engine = create_async_engine(database_url, echo=False)
+    return _engine
+
+
+def get_async_session_factory():
+    """Get async session factory with lazy initialization."""
+    global _async_session
+    if _async_session is None:
+        engine = get_engine()
+        _async_session = async_sessionmaker(
+            engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+        )
+    return _async_session
 
 
 class Provider(str, Enum):
@@ -103,16 +118,19 @@ class RateLimitBucket(SQLModel, table=True):
 # Database lifecycle management
 async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
     """Get async database session for dependency injection."""
-    async with async_session() as session:
+    async_session_factory = get_async_session_factory()
+    async with async_session_factory() as session:
         yield session
 
 
 async def create_all_tables() -> None:
     """Create all database tables."""
+    engine = get_engine()
     async with engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
 
 
 async def close_db() -> None:
     """Close database connections."""
+    engine = get_engine()
     await engine.dispose()

--- a/services/office/test_service_auth.py
+++ b/services/office/test_service_auth.py
@@ -1,0 +1,102 @@
+import asyncio
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from fastapi import Request
+
+
+@pytest.fixture(autouse=True)
+def patch_settings(monkeypatch):
+    """Patch the get_settings function to return test settings."""
+    import services.office.core.settings as office_settings
+
+    def _test_settings():
+        return office_settings.Settings(
+            db_url_office="sqlite:///:memory:",
+            api_frontend_office_key="test-FRONTEND_OFFICE_KEY",
+            api_chat_office_key="test-CHAT_OFFICE_KEY",
+        )
+
+    monkeypatch.setattr("services.office.core.settings.get_settings", _test_settings)
+
+
+class TestServiceAuth:
+    def test_get_client_permissions(self):
+        from services.office.core.auth import get_test_api_keys
+
+        api_keys = get_test_api_keys()
+        assert "frontend" in api_keys
+        assert "chat" in api_keys
+        assert api_keys["frontend"] == "test-FRONTEND_OFFICE_KEY"
+        assert api_keys["chat"] == "test-CHAT_OFFICE_KEY"
+
+    def test_verify_api_key_for_testing(self):
+        from services.office.core.auth import verify_api_key_for_testing
+
+        # Test with valid frontend key
+        result = verify_api_key_for_testing("test-FRONTEND_OFFICE_KEY")
+        assert result == "office-service-access"
+
+        # Test with valid chat key
+        result = verify_api_key_for_testing("test-CHAT_OFFICE_KEY")
+        assert result == "office-service-access"
+
+        # Test with invalid key
+        result = verify_api_key_for_testing("invalid-key")
+        assert result is None
+
+    def test_verify_service_authentication_success(self):
+        from services.office.core.auth import verify_service_authentication
+
+        request = MagicMock(spec=Request)
+        request.headers = {"Authorization": "Bearer test-FRONTEND_OFFICE_KEY"}
+        request.state = Mock()
+        service_name = verify_service_authentication(request)
+        assert service_name == "office-service-access"
+
+    def test_verify_service_authentication_invalid_key(self):
+        from services.office.core.auth import verify_service_authentication
+
+        request = MagicMock(spec=Request)
+        request.headers = {"Authorization": "Bearer invalid-key"}
+        request.state = Mock()
+        with pytest.raises(Exception):
+            verify_service_authentication(request)
+
+    def test_service_permission_required_success(self):
+        from services.office.core.auth import service_permission_required
+
+        request = MagicMock(spec=Request)
+        request.headers = {"Authorization": "Bearer test-FRONTEND_OFFICE_KEY"}
+        request.state = Mock()
+        dep = service_permission_required(["read_emails"])
+        service_name = asyncio.run(dep(request))
+        assert service_name == "office-service-access"
+
+    def test_service_permission_required_failure(self):
+        from services.office.core.auth import service_permission_required
+
+        request = MagicMock(spec=Request)
+        request.headers = {"Authorization": "Bearer test-FRONTEND_OFFICE_KEY"}
+        request.state = Mock()
+        dep = service_permission_required(["not_a_permission"])
+        with pytest.raises(Exception):
+            asyncio.run(dep(request))
+
+    def test_optional_service_auth_success(self):
+        from services.office.core.auth import optional_service_auth
+
+        request = MagicMock(spec=Request)
+        request.headers = {"Authorization": "Bearer test-FRONTEND_OFFICE_KEY"}
+        request.state = Mock()
+        service_name = optional_service_auth(request)
+        assert service_name == "office-service-access"
+
+    def test_optional_service_auth_failure(self):
+        from services.office.core.auth import optional_service_auth
+
+        request = MagicMock(spec=Request)
+        request.headers = {"Authorization": "Bearer invalid-key"}
+        request.state = Mock()
+        service_name = optional_service_auth(request)
+        assert service_name is None

--- a/services/office/tests/test_api_clients.py
+++ b/services/office/tests/test_api_clients.py
@@ -20,7 +20,7 @@ from services.office.models import Provider
 
 
 @pytest.fixture(autouse=True)
-def patch_settings(monkeypatch):
+def patch_settings():
     """Patch the _settings global variable to return test settings."""
     import services.office.core.settings as office_settings
 
@@ -31,7 +31,10 @@ def patch_settings(monkeypatch):
         api_office_user_key="test-office-user-key",
     )
 
-    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+    # Directly set the singleton instead of using monkeypatch
+    office_settings._settings = test_settings
+    yield
+    office_settings._settings = None
 
 
 class MockAPIClient(BaseAPIClient):

--- a/services/office/tests/test_api_clients.py
+++ b/services/office/tests/test_api_clients.py
@@ -26,6 +26,21 @@ from services.office.core.token_manager import TokenData
 from services.office.models import Provider
 
 
+@pytest.fixture(autouse=True)
+def patch_settings(monkeypatch):
+    """Patch the _settings global variable to return test settings."""
+    import services.office.core.settings as office_settings
+
+    test_settings = office_settings.Settings(
+        db_url_office="sqlite:///:memory:",
+        api_frontend_office_key="test-frontend-office-key",
+        api_chat_office_key="test-chat-office-key",
+        api_office_user_key="test-office-user-key",
+    )
+
+    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+
+
 class MockAPIClient(BaseAPIClient):
     """Mock API client for testing base functionality."""
 

--- a/services/office/tests/test_api_clients.py
+++ b/services/office/tests/test_api_clients.py
@@ -20,7 +20,7 @@ from services.office.models import Provider
 
 
 @pytest.fixture(autouse=True)
-def patch_settings():
+def patch_settings(monkeypatch):
     """Patch the _settings global variable to return test settings."""
     import services.office.core.settings as office_settings
 
@@ -31,10 +31,7 @@ def patch_settings():
         api_office_user_key="test-office-user-key",
     )
 
-    # Directly set the singleton instead of using monkeypatch
-    office_settings._settings = test_settings
-    yield
-    office_settings._settings = None
+    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
 
 
 class MockAPIClient(BaseAPIClient):

--- a/services/office/tests/test_api_clients.py
+++ b/services/office/tests/test_api_clients.py
@@ -5,13 +5,6 @@ Tests the base API client, provider-specific clients (Google, Microsoft),
 and API client factory with mocked HTTP responses and error handling.
 """
 
-# Set required environment variables before any imports
-import os
-
-os.environ.setdefault("DB_URL_OFFICE", "sqlite:///test.db")
-os.environ.setdefault("API_OFFICE_USER_KEY", "test-api-key")
-
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/services/office/tests/test_api_email.py
+++ b/services/office/tests/test_api_email.py
@@ -5,13 +5,6 @@ Tests email listing, searching, sending, and management functionality
 for both Google and Microsoft providers with comprehensive error handling.
 """
 
-# Set required environment variables before any imports
-import os
-
-os.environ.setdefault("DB_URL_OFFICE", "sqlite:///test.db")
-os.environ.setdefault("API_OFFICE_USER_KEY", "test-api-key")
-
-
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 

--- a/services/office/tests/test_api_email.py
+++ b/services/office/tests/test_api_email.py
@@ -17,7 +17,7 @@ from services.office.schemas import EmailAddress, EmailMessage, SendEmailRequest
 
 
 @pytest.fixture(autouse=True)
-def patch_settings(monkeypatch):
+def patch_settings():
     """Patch the _settings global variable to return test settings."""
     import services.office.core.settings as office_settings
 
@@ -28,7 +28,10 @@ def patch_settings(monkeypatch):
         api_office_user_key="test-office-user-key",
     )
 
-    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+    # Directly set the singleton instead of using monkeypatch
+    office_settings._settings = test_settings
+    yield
+    office_settings._settings = None
 
 
 @pytest.fixture

--- a/services/office/tests/test_api_email.py
+++ b/services/office/tests/test_api_email.py
@@ -23,6 +23,21 @@ from services.office.models import Provider
 from services.office.schemas import EmailAddress, EmailMessage, SendEmailRequest
 
 
+@pytest.fixture(autouse=True)
+def patch_settings(monkeypatch):
+    """Patch the _settings global variable to return test settings."""
+    import services.office.core.settings as office_settings
+
+    test_settings = office_settings.Settings(
+        db_url_office="sqlite:///:memory:",
+        api_frontend_office_key="test-frontend-office-key",
+        api_chat_office_key="test-chat-office-key",
+        api_office_user_key="test-office-user-key",
+    )
+
+    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+
+
 @pytest.fixture
 def client():
     """Create a test client for the FastAPI application."""
@@ -31,8 +46,11 @@ def client():
 
 @pytest.fixture
 def auth_headers():
-    """Create authentication headers with X-User-Id."""
-    return {"X-User-Id": "test_user"}
+    """Create authentication headers with X-User-Id and API key."""
+    return {
+        "X-User-Id": "test_user",
+        "X-API-Key": "test-frontend-office-key"
+    }
 
 
 @pytest.fixture

--- a/services/office/tests/test_api_email.py
+++ b/services/office/tests/test_api_email.py
@@ -47,10 +47,7 @@ def client():
 @pytest.fixture
 def auth_headers():
     """Create authentication headers with X-User-Id and API key."""
-    return {
-        "X-User-Id": "test_user",
-        "X-API-Key": "test-frontend-office-key"
-    }
+    return {"X-User-Id": "test_user", "X-API-Key": "test-frontend-office-key"}
 
 
 @pytest.fixture
@@ -191,7 +188,9 @@ class TestEmailMessagesEndpoint:
     @pytest.mark.asyncio
     async def test_get_email_messages_missing_user_id(self, client):
         """Test email messages without X-User-Id header."""
-        response = client.get("/email/messages")
+        # Include API key but not user ID
+        headers = {"X-API-Key": "test-frontend-office-key"}
+        response = client.get("/email/messages", headers=headers)
 
         assert response.status_code == 422  # Validation error
 
@@ -427,9 +426,12 @@ class TestSendEmailEndpoint:
     @pytest.mark.asyncio
     async def test_send_email_missing_user_id(self, send_email_request, client):
         """Test sending email without X-User-Id header."""
+        # Include API key but not user ID
+        headers = {"X-API-Key": "test-frontend-office-key"}
         response = client.post(
             "/email/send",
             json=send_email_request.model_dump(),
+            headers=headers,
         )
 
         assert response.status_code == 422  # Validation error

--- a/services/office/tests/test_auth.py
+++ b/services/office/tests/test_auth.py
@@ -133,6 +133,7 @@ class TestAPIKeyFunctions:
             "write_calendar",
             "read_files",
             "write_files",
+            "health",
         ]
         assert permissions == expected
 
@@ -142,7 +143,7 @@ class TestAPIKeyFunctions:
         permissions = get_permissions_from_api_key(
             get_test_api_keys()["chat"], api_key_mapping
         )
-        expected = ["read_emails", "read_calendar", "read_files"]
+        expected = ["read_emails", "read_calendar", "read_files", "health"]
         assert permissions == expected
 
     def test_get_permissions_from_api_key_invalid(self):
@@ -554,6 +555,7 @@ class TestPermissionMatrix:
             "write_calendar",
             "read_files",
             "write_files",
+            "health",
         ]
 
         for permission in expected:

--- a/services/office/tests/test_auth.py
+++ b/services/office/tests/test_auth.py
@@ -30,6 +30,21 @@ from services.office.core.auth import (
 from services.office.core.settings import get_settings
 
 
+@pytest.fixture(autouse=True)
+def patch_settings(monkeypatch):
+    """Patch the _settings global variable to return test settings."""
+    import services.office.core.settings as office_settings
+
+    test_settings = office_settings.Settings(
+        db_url_office="sqlite:///:memory:",
+        api_frontend_office_key="test-frontend-office-key",
+        api_chat_office_key="test-chat-office-key",
+        api_office_user_key="test-office-user-key",
+    )
+
+    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+
+
 # Test settings fixture
 @pytest.fixture(scope="session")
 def test_settings():

--- a/services/office/tests/test_auth.py
+++ b/services/office/tests/test_auth.py
@@ -31,7 +31,7 @@ from services.office.core.settings import get_settings
 
 
 @pytest.fixture(autouse=True)
-def patch_settings(monkeypatch):
+def patch_settings():
     """Patch the _settings global variable to return test settings."""
     import services.office.core.settings as office_settings
 
@@ -42,7 +42,10 @@ def patch_settings(monkeypatch):
         api_office_user_key="test-office-user-key",
     )
 
-    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+    # Directly set the singleton instead of using monkeypatch
+    office_settings._settings = test_settings
+    yield
+    office_settings._settings = None
 
 
 # Test settings fixture

--- a/services/office/tests/test_error_handling.py
+++ b/services/office/tests/test_error_handling.py
@@ -22,7 +22,7 @@ from services.office.models import Provider
 
 
 @pytest.fixture(autouse=True)
-def patch_settings(monkeypatch):
+def patch_settings():
     """Patch the _settings global variable to return test settings."""
     import services.office.core.settings as office_settings
 
@@ -33,7 +33,10 @@ def patch_settings(monkeypatch):
         api_office_user_key="test-office-user-key",
     )
 
-    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+    # Directly set the singleton instead of using monkeypatch
+    office_settings._settings = test_settings
+    yield
+    office_settings._settings = None
 
 
 class TestGlobalExceptionHandlers:

--- a/services/office/tests/test_error_handling.py
+++ b/services/office/tests/test_error_handling.py
@@ -28,6 +28,21 @@ from services.office.core.clients.google import GoogleAPIClient
 from services.office.models import Provider
 
 
+@pytest.fixture(autouse=True)
+def patch_settings(monkeypatch):
+    """Patch the _settings global variable to return test settings."""
+    import services.office.core.settings as office_settings
+
+    test_settings = office_settings.Settings(
+        db_url_office="sqlite:///:memory:",
+        api_frontend_office_key="test-frontend-office-key",
+        api_chat_office_key="test-chat-office-key",
+        api_office_user_key="test-office-user-key",
+    )
+
+    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+
+
 class TestGlobalExceptionHandlers:
     """Test the global exception handlers defined in main.py"""
 

--- a/services/office/tests/test_error_handling.py
+++ b/services/office/tests/test_error_handling.py
@@ -5,13 +5,6 @@ Tests error handling, exception propagation, and error response formatting
 for various failure scenarios in the office service.
 """
 
-# Set required environment variables before any imports
-import os
-
-os.environ.setdefault("DB_URL_OFFICE", "sqlite:///test.db")
-os.environ.setdefault("API_OFFICE_USER_KEY", "test-api-key")
-
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/services/office/tests/test_integration.py
+++ b/services/office/tests/test_integration.py
@@ -23,6 +23,21 @@ from services.office.core.settings import get_settings
 from services.office.core.token_manager import TokenData
 
 
+@pytest.fixture(autouse=True)
+def patch_settings(monkeypatch):
+    """Patch the _settings global variable to return test settings."""
+    import services.office.core.settings as office_settings
+
+    test_settings = office_settings.Settings(
+        db_url_office="sqlite:///:memory:",
+        api_frontend_office_key="test-frontend-office-key",
+        api_chat_office_key="test-chat-office-key",
+        api_office_user_key="test-office-user-key",
+    )
+
+    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+
+
 # Helper function to get API key values
 def get_test_api_keys():
     """Get the actual API key values from settings for testing."""

--- a/services/office/tests/test_integration.py
+++ b/services/office/tests/test_integration.py
@@ -274,7 +274,9 @@ class TestEmailEndpoints(BaseOfficeServiceIntegrationTest):
 
     def test_get_email_messages_missing_user_id(self):
         """Test email messages endpoint without user_id parameter."""
-        response = self.client.get("/email/messages")
+        # Include API key but not user ID
+        headers = {"X-API-Key": "test-frontend-office-key"}
+        response = self.client.get("/email/messages", headers=headers)
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     def test_get_email_message_by_id_success(self):
@@ -664,13 +666,13 @@ class TestErrorScenarios(BaseOfficeServiceIntegrationTest):
     def test_authentication_failure(self):
         """Test handling of authentication failures."""
         # Test without API key
-        response = self.client.get("/calendar/events", headers=self.auth_headers)
+        response = self.client.get("/calendar/events")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
         # Test with invalid API key
         response = self.client.get(
             "/calendar/events",
-            headers={**self.auth_headers, "X-API-Key": "invalid-key"},
+            headers={"X-API-Key": "invalid-key"},
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 

--- a/services/office/tests/test_integration.py
+++ b/services/office/tests/test_integration.py
@@ -24,7 +24,7 @@ from services.office.core.token_manager import TokenData
 
 
 @pytest.fixture(autouse=True)
-def patch_settings(monkeypatch):
+def patch_settings():
     """Patch the _settings global variable to return test settings."""
     import services.office.core.settings as office_settings
 
@@ -35,7 +35,10 @@ def patch_settings(monkeypatch):
         api_office_user_key="test-office-user-key",
     )
 
-    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+    # Directly set the singleton instead of using monkeypatch
+    office_settings._settings = test_settings
+    yield
+    office_settings._settings = None
 
 
 # Helper function to get API key values

--- a/services/office/tests/test_integration.py
+++ b/services/office/tests/test_integration.py
@@ -51,7 +51,7 @@ class TestHealthEndpoints(BaseOfficeServiceIntegrationTest):
                     "services.office.api.health.check_service_connection",
                     return_value=True,
                 ):
-                    response = self.client.get("/health")
+                    response = self.client.get("/health", headers=self.auth_headers)
                     assert response.status_code == status.HTTP_200_OK
 
                     data = response.json()
@@ -79,7 +79,9 @@ class TestHealthEndpoints(BaseOfficeServiceIntegrationTest):
             "services.office.core.token_manager.TokenManager.get_user_token",
             return_value=mock_token_data,
         ):
-            response = self.client.get(f"/health/integrations/{user_id}")
+            response = self.client.get(
+                f"/health/integrations/{user_id}", headers=self.auth_headers
+            )
             assert response.status_code == status.HTTP_200_OK
 
             data = response.json()
@@ -112,7 +114,9 @@ class TestHealthEndpoints(BaseOfficeServiceIntegrationTest):
             "services.office.core.token_manager.TokenManager.get_user_token",
             side_effect=failing_token_side_effect,
         ):
-            response = self.client.get(f"/health/integrations/{user_id}")
+            response = self.client.get(
+                f"/health/integrations/{user_id}", headers=self.auth_headers
+            )
             assert response.status_code == status.HTTP_200_OK
 
             data = response.json()

--- a/services/office/tests/test_schemas.py
+++ b/services/office/tests/test_schemas.py
@@ -29,6 +29,21 @@ from services.office.schemas import (
 )
 
 
+@pytest.fixture(autouse=True)
+def patch_settings(monkeypatch):
+    """Patch the _settings global variable to return test settings."""
+    import services.office.core.settings as office_settings
+
+    test_settings = office_settings.Settings(
+        db_url_office="sqlite:///:memory:",
+        api_frontend_office_key="test-frontend-office-key",
+        api_chat_office_key="test-chat-office-key",
+        api_office_user_key="test-office-user-key",
+    )
+
+    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+
+
 class TestEmailAddress:
     """Tests for EmailAddress model."""
 

--- a/services/office/tests/test_schemas.py
+++ b/services/office/tests/test_schemas.py
@@ -5,13 +5,6 @@ Tests schema validation, serialization, deserialization,
 and data transformation for office service models.
 """
 
-# Set required environment variables before any imports
-import os
-
-os.environ.setdefault("DB_URL_OFFICE", "sqlite:///test.db")
-os.environ.setdefault("API_OFFICE_USER_KEY", "test-api-key")
-
-
 from datetime import datetime, timezone
 
 import pytest

--- a/services/office/tests/test_schemas.py
+++ b/services/office/tests/test_schemas.py
@@ -23,7 +23,7 @@ from services.office.schemas import (
 
 
 @pytest.fixture(autouse=True)
-def patch_settings(monkeypatch):
+def patch_settings():
     """Patch the _settings global variable to return test settings."""
     import services.office.core.settings as office_settings
 
@@ -34,7 +34,10 @@ def patch_settings(monkeypatch):
         api_office_user_key="test-office-user-key",
     )
 
-    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+    # Directly set the singleton instead of using monkeypatch
+    office_settings._settings = test_settings
+    yield
+    office_settings._settings = None
 
 
 class TestEmailAddress:

--- a/services/office/tests/test_token_manager.py
+++ b/services/office/tests/test_token_manager.py
@@ -21,7 +21,7 @@ from services.office.core.token_manager import TokenData, TokenManager
 
 
 @pytest.fixture(autouse=True)
-def patch_settings(monkeypatch):
+def patch_settings():
     """Patch the _settings global variable to return test settings."""
     import services.office.core.settings as office_settings
 
@@ -32,7 +32,10 @@ def patch_settings(monkeypatch):
         api_office_user_key="test-office-user-key",
     )
 
-    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+    # Directly set the singleton instead of using monkeypatch
+    office_settings._settings = test_settings
+    yield
+    office_settings._settings = None
 
 
 class TestTokenManager:

--- a/services/office/tests/test_token_manager.py
+++ b/services/office/tests/test_token_manager.py
@@ -20,6 +20,21 @@ import pytest
 from services.office.core.token_manager import TokenData, TokenManager
 
 
+@pytest.fixture(autouse=True)
+def patch_settings(monkeypatch):
+    """Patch the _settings global variable to return test settings."""
+    import services.office.core.settings as office_settings
+
+    test_settings = office_settings.Settings(
+        db_url_office="sqlite:///:memory:",
+        api_frontend_office_key="test-frontend-office-key",
+        api_chat_office_key="test-chat-office-key",
+        api_office_user_key="test-office-user-key",
+    )
+
+    monkeypatch.setattr("services.office.core.settings._settings", test_settings)
+
+
 class TestTokenManager:
     """Tests for TokenManager class."""
 

--- a/services/user/tests/test_email_collision.py
+++ b/services/user/tests/test_email_collision.py
@@ -174,6 +174,19 @@ class TestEmailNormalization:
 async def db_setup(monkeypatch):
     db_fd, db_path = tempfile.mkstemp(suffix=".db")
     os.environ["DB_URL_USER_MANAGEMENT"] = f"sqlite+aiosqlite:///{db_path}"
+
+    # Patch the global _settings variable to include required API keys
+    import services.user.settings as user_settings
+
+    test_settings = user_settings.Settings(
+        db_url_user_management=f"sqlite+aiosqlite:///{db_path}",
+        api_frontend_user_key="test-frontend-key",
+        api_chat_user_key="test-chat-key",
+        api_office_user_key="test-office-key",
+        token_encryption_salt="dGVzdC1zYWx0LTE2Ynl0ZQ==",
+    )
+    monkeypatch.setattr("services.user.settings._settings", test_settings)
+
     await create_all_tables()
     yield
     os.close(db_fd)


### PR DESCRIPTION
- Implement shared API key authentication and permission logic in office service using the common helpers, following the pattern from shipments service.
- Add permission-based FastAPI dependencies to all endpoints in email.py and health.py (read/write separation with new 'health' permission).
- Add test_service_auth.py with tests for API key authentication and permission logic, patching the settings singleton for robust test isolation.
- Update settings to make API keys required (no defaults) to prevent production mistakes.
- Update test infrastructure to include API key headers in integration tests.
- Follows the service_permission_required refactor pattern from user, chat, and shipments services for consistency and security.

Permissions added:
- read_emails: for reading email messages
- send_emails: for sending emails
- health: for health monitoring endpoints
- read_calendar/write_calendar: already existed
- read_files/write_files: already existed