### PR TITLE
feat: improve meeting poll UI and move delete functionality

### DIFF
--- a/frontend/app/dashboard/meetings/[id]/edit/page.tsx
+++ b/frontend/app/dashboard/meetings/[id]/edit/page.tsx
@@ -17,6 +17,7 @@ const EditMeetingPollPage = () => {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [saving, setSaving] = useState(false);
+    const [deleting, setDeleting] = useState(false);
     const [title, setTitle] = useState("");
     const [description, setDescription] = useState("");
     const [duration, setDuration] = useState(60);
@@ -60,6 +61,24 @@ const EditMeetingPollPage = () => {
         }
     };
 
+    const handleDelete = async () => {
+        if (!window.confirm('Are you sure you want to delete this meeting poll?')) return;
+        setDeleting(true);
+        setError(null);
+        try {
+            await gatewayClient.deleteMeetingPoll(id);
+            router.push("/dashboard?tool=meetings");
+        } catch (e: unknown) {
+            if (e && typeof e === 'object' && 'message' in e) {
+                setError((e as { message?: string }).message || "Failed to delete poll");
+            } else {
+                setError("Failed to delete poll");
+            }
+        } finally {
+            setDeleting(false);
+        }
+    };
+
     return (
         <div className="max-w-xl mx-auto p-8">
             <h1 className="text-2xl font-bold mb-6">Edit Meeting Poll</h1>
@@ -86,9 +105,28 @@ const EditMeetingPollPage = () => {
                         <input className="w-full border rounded px-3 py-2" value={location} onChange={e => setLocation(e.target.value)} />
                     </div>
                     {error && <div className="text-red-600">{error}</div>}
-                    <button type="submit" className="w-full bg-teal-600 text-white py-2 rounded font-semibold hover:bg-teal-700" disabled={saving}>
-                        {saving ? "Saving..." : "Save Changes"}
-                    </button>
+                    <div className="flex gap-3">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard?tool=meetings")}
+                            className="flex-1 bg-gray-800 text-white py-2 rounded font-semibold hover:bg-gray-900"
+                        >
+                            Cancel
+                        </button>
+                        <button type="submit" className="flex-1 bg-teal-600 text-white py-2 rounded font-semibold hover:bg-teal-700" disabled={saving}>
+                            {saving ? "Saving..." : "Save Changes"}
+                        </button>
+                    </div>
+                    <div className="pt-4 border-t">
+                        <button
+                            type="button"
+                            onClick={handleDelete}
+                            disabled={deleting}
+                            className="w-full bg-red-600 text-white py-2 rounded font-semibold hover:bg-red-700 disabled:opacity-50"
+                        >
+                            {deleting ? "Deleting..." : "Delete Meeting Poll"}
+                        </button>
+                    </div>
                 </form>
             )}
         </div>

--- a/frontend/components/tool-content.tsx
+++ b/frontend/components/tool-content.tsx
@@ -94,7 +94,6 @@ export function ToolContent() {
     const [polls, setPolls] = useState<MeetingPoll[]>([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const [deletingId, setDeletingId] = useState<string | null>(null);
 
     const fetchPolls = () => {
         setLoading(true);
@@ -117,22 +116,7 @@ export function ToolContent() {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeTool]);
 
-    const handleDelete = async (id: string) => {
-        if (!window.confirm('Are you sure you want to delete this meeting poll?')) return;
-        setDeletingId(id);
-        try {
-            await gatewayClient.deleteMeetingPoll(id);
-            fetchPolls();
-        } catch (e: unknown) {
-            if (e && typeof e === 'object' && 'message' in e) {
-                alert((e as { message?: string }).message || 'Failed to delete poll');
-            } else {
-                alert('Failed to delete poll');
-            }
-        } finally {
-            setDeletingId(null);
-        }
-    };
+
 
     const renderToolContent = () => {
         switch (activeTool) {
@@ -295,21 +279,14 @@ export function ToolContent() {
                                         <tr key={poll.id} className="hover:bg-gray-50">
                                             <td className="px-4 py-2 border-b font-medium">{poll.title}</td>
                                             <td className="px-4 py-2 border-b capitalize">{poll.status}</td>
-                                            <td className="px-4 py-2 border-b">{poll.created_at?.slice(0, 10) || ""}</td>
+                                            <td className="px-4 py-2 border-b whitespace-nowrap">{poll.created_at?.slice(0, 10) || ""}</td>
                                             <td className="px-4 py-2 border-b space-x-2">
                                                 <Link href={`/dashboard/meetings/${poll.id}`} className="text-teal-600 hover:underline font-semibold">
-                                                    View Results
+                                                    View
                                                 </Link>
                                                 <Link href={`/dashboard/meetings/${poll.id}/edit`} className="text-blue-600 hover:underline font-semibold">
                                                     Edit
                                                 </Link>
-                                                <button
-                                                    className="text-red-600 hover:underline font-semibold disabled:opacity-50"
-                                                    onClick={() => handleDelete(poll.id)}
-                                                    disabled={deletingId === poll.id}
-                                                >
-                                                    {deletingId === poll.id ? "Deleting..." : "Delete"}
-                                                </button>
                                             </td>
                                         </tr>
                                     ))}


### PR DESCRIPTION
- Add cancel and delete buttons to edit meeting poll page
- Remove delete button from meeting poll list for better UX
- Change "View Results" link text to "View" for brevity
- Fix date wrapping in meeting poll table with whitespace-nowrap
- Style cancel button as black and delete button as red