### PR TITLE
feat: simplify draft pane UI when no draft is active

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -67,9 +67,11 @@ function DashboardContent() {
                     </div>
                     {/* Draft Pane - Bottom portion */}
                     <div className="h-80 border-t bg-card">
-                        <div className="flex items-center justify-between p-4 border-b">
-                            <h2 className="text-lg font-semibold">Draft</h2>
-                        </div>
+                        {draftState.currentDraft && (
+                            <div className="flex items-center justify-between p-4 border-b">
+                                <h2 className="text-lg font-semibold">Draft</h2>
+                            </div>
+                        )}
                         <div className="flex-1 overflow-hidden">
                             <DraftPane
                                 draft={draftState.currentDraft}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -66,13 +66,13 @@ function DashboardContent() {
                         <ToolContent />
                     </div>
                     {/* Draft Pane - Bottom portion */}
-                    <div className="h-80 border-t bg-card">
+                    <div className={draftState.currentDraft ? "h-80 border-t bg-card" : "border-t bg-card"}>
                         {draftState.currentDraft && (
                             <div className="flex items-center justify-between p-4 border-b">
                                 <h2 className="text-lg font-semibold">Draft</h2>
                             </div>
                         )}
-                        <div className="flex-1 overflow-hidden">
+                        <div className={draftState.currentDraft ? "flex-1 overflow-hidden" : ""}>
                             <DraftPane
                                 draft={draftState.currentDraft}
                                 onUpdate={updateDraft}

--- a/frontend/components/draft/draft-editor.tsx
+++ b/frontend/components/draft/draft-editor.tsx
@@ -12,6 +12,7 @@ interface DraftEditorProps {
     onAutoSave?: (content: string) => void;
     className?: string;
     disabled?: boolean;
+    updatedAt?: string;
 }
 
 export function DraftEditor({
@@ -20,7 +21,8 @@ export function DraftEditor({
     onUpdate,
     onAutoSave,
     className,
-    disabled = false
+    disabled = false,
+    updatedAt
 }: DraftEditorProps) {
     const renderEditor = () => {
         switch (type) {
@@ -32,6 +34,7 @@ export function DraftEditor({
                         onAutoSave={onAutoSave}
                         className={className}
                         disabled={disabled}
+                        updatedAt={updatedAt}
                     />
                 );
             case 'email':
@@ -42,6 +45,7 @@ export function DraftEditor({
                         onAutoSave={onAutoSave}
                         className={className}
                         disabled={disabled}
+                        updatedAt={updatedAt}
                     />
                 );
             case 'calendar':
@@ -52,6 +56,7 @@ export function DraftEditor({
                         onAutoSave={onAutoSave}
                         className={className}
                         disabled={disabled}
+                        updatedAt={updatedAt}
                     />
                 );
             default:
@@ -62,6 +67,7 @@ export function DraftEditor({
                         onAutoSave={onAutoSave}
                         className={className}
                         disabled={disabled}
+                        updatedAt={updatedAt}
                     />
                 );
         }

--- a/frontend/components/draft/draft-pane.tsx
+++ b/frontend/components/draft/draft-pane.tsx
@@ -71,7 +71,7 @@ export function DraftPane({ className, draft, onUpdate, onMetadataChange, onType
     if (!draft) {
         return (
             <div className={cn(
-                'h-full flex flex-col items-center justify-center p-6',
+                'flex flex-col items-center justify-center p-4',
                 className
             )}>
                 <DraftTypeSwitcher

--- a/frontend/components/draft/draft-pane.tsx
+++ b/frontend/components/draft/draft-pane.tsx
@@ -71,26 +71,14 @@ export function DraftPane({ className, draft, onUpdate, onMetadataChange, onType
     if (!draft) {
         return (
             <div className={cn(
-                'h-full flex flex-col items-center justify-center p-6 text-center',
+                'h-full flex flex-col items-center justify-center p-6',
                 className
             )}>
-                <div className="max-w-sm space-y-4">
-                    <div className="text-muted-foreground">
-                        <h3 className="text-lg font-medium mb-2">No Draft Selected</h3>
-                        <p className="text-sm">
-                            Create a new draft or select an existing one to get started.
-                        </p>
-                    </div>
-
-                    <div className="space-y-2">
-                        <p className="text-xs text-muted-foreground">Choose a draft type:</p>
-                        <DraftTypeSwitcher
-                            currentType="email"
-                            onTypeChange={handleTypeChange}
-                            className="justify-center"
-                        />
-                    </div>
-                </div>
+                <DraftTypeSwitcher
+                    currentType="email"
+                    onTypeChange={handleTypeChange}
+                    className="justify-center"
+                />
             </div>
         );
     }

--- a/frontend/components/draft/draft-pane.tsx
+++ b/frontend/components/draft/draft-pane.tsx
@@ -4,7 +4,6 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { Draft, DraftMetadata, DraftType } from '@/types/draft';
 import { Calendar, FileText, Mail } from 'lucide-react';
-import { AIIndicator } from './ai-indicator';
 import { DraftActions } from './draft-actions';
 import { DraftEditor } from './draft-editor';
 import { DraftMetadata as DraftMetadataComponent } from './draft-metadata';
@@ -102,23 +101,6 @@ export function DraftPane({ className, draft, onUpdate, onMetadataChange, onType
             'h-full flex flex-col bg-background',
             className
         )}>
-            {/* Header */}
-            <div className="flex items-center justify-between p-4 border-b">
-                <div className="flex items-center gap-3">
-                    {draft.isAIGenerated && (
-                        <AIIndicator isAIGenerated={true} size="sm" />
-                    )}
-                </div>
-
-                <div className="text-xs text-muted-foreground">
-                    {draft.updatedAt && (
-                        <span>
-                            Last updated: {new Date(draft.updatedAt).toLocaleTimeString()}
-                        </span>
-                    )}
-                </div>
-            </div>
-
             {/* Metadata */}
             <DraftMetadataComponent
                 draft={draft}
@@ -144,6 +126,7 @@ export function DraftPane({ className, draft, onUpdate, onMetadataChange, onType
                     onUpdate={handleContentChange}
                     onAutoSave={handleAutoSave}
                     disabled={isLoading}
+                    updatedAt={draft.updatedAt}
                 />
             </div>
 

--- a/frontend/components/draft/draft-pane.tsx
+++ b/frontend/components/draft/draft-pane.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { Draft, DraftMetadata, DraftType } from '@/types/draft';
+import { Calendar, FileText, Mail } from 'lucide-react';
 import { AIIndicator } from './ai-indicator';
 import { DraftActions } from './draft-actions';
 import { DraftEditor } from './draft-editor';
 import { DraftMetadata as DraftMetadataComponent } from './draft-metadata';
-import { DraftTypeSwitcher } from './draft-type-switcher';
 
 interface DraftPaneProps {
     className?: string;
@@ -20,6 +21,12 @@ interface DraftPaneProps {
 }
 
 export function DraftPane({ className, draft, onUpdate, onMetadataChange, onTypeChange, isLoading = false, error = null, onActionComplete }: DraftPaneProps) {
+    const draftTypes: { type: DraftType; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
+        { type: 'email', label: 'Email', icon: Mail },
+        { type: 'calendar', label: 'Calendar', icon: Calendar },
+        { type: 'document', label: 'Document', icon: FileText },
+    ];
+
     const handleTypeChange = (type: DraftType) => {
         if (draft && draft.type !== type) {
             // If there's unsaved content, ask for confirmation
@@ -74,11 +81,18 @@ export function DraftPane({ className, draft, onUpdate, onMetadataChange, onType
                 'flex flex-col items-center justify-center p-4',
                 className
             )}>
-                <DraftTypeSwitcher
-                    currentType="email"
-                    onTypeChange={handleTypeChange}
-                    className="justify-center"
-                />
+                <div className="flex flex-wrap gap-2 justify-center">
+                    {draftTypes.map(({ type, label, icon: Icon }) => (
+                        <Button
+                            key={type}
+                            onClick={() => handleTypeChange(type)}
+                            className="flex items-center gap-2 px-4 py-2"
+                        >
+                            <Icon className="h-4 w-4" />
+                            {label}
+                        </Button>
+                    ))}
+                </div>
             </div>
         );
     }
@@ -91,10 +105,6 @@ export function DraftPane({ className, draft, onUpdate, onMetadataChange, onType
             {/* Header */}
             <div className="flex items-center justify-between p-4 border-b">
                 <div className="flex items-center gap-3">
-                    <DraftTypeSwitcher
-                        currentType={draft.type}
-                        onTypeChange={handleTypeChange}
-                    />
                     {draft.isAIGenerated && (
                         <AIIndicator isAIGenerated={true} size="sm" />
                     )}

--- a/frontend/components/draft/editors/calendar-editor.tsx
+++ b/frontend/components/draft/editors/calendar-editor.tsx
@@ -13,6 +13,7 @@ interface CalendarEditorProps {
     placeholder?: string;
     className?: string;
     disabled?: boolean;
+    updatedAt?: string;
 }
 
 export function CalendarEditor({
@@ -20,7 +21,8 @@ export function CalendarEditor({
     onUpdate,
     onAutoSave,
     className,
-    disabled = false
+    disabled = false,
+    updatedAt
 }: CalendarEditorProps) {
     const { editor, validateContent, getWordCount, getCharacterCount } = useEditor({
         content,
@@ -77,11 +79,18 @@ export function CalendarEditor({
                     )}
                 </div>
 
-                {onAutoSave && (
-                    <span className="text-green-600">
-                        Auto-save enabled
-                    </span>
-                )}
+                <div className="flex items-center gap-4">
+                    {updatedAt && (
+                        <span>
+                            Last updated: {new Date(updatedAt).toLocaleTimeString()}
+                        </span>
+                    )}
+                    {onAutoSave && (
+                        <span className="text-green-600">
+                            Auto-save enabled
+                        </span>
+                    )}
+                </div>
             </div>
 
             {/* Error Display */}

--- a/frontend/components/draft/editors/document-editor.tsx
+++ b/frontend/components/draft/editors/document-editor.tsx
@@ -13,6 +13,7 @@ interface DocumentEditorProps {
     placeholder?: string;
     className?: string;
     disabled?: boolean;
+    updatedAt?: string;
 }
 
 export function DocumentEditor({
@@ -20,7 +21,8 @@ export function DocumentEditor({
     onUpdate,
     onAutoSave,
     className,
-    disabled = false
+    disabled = false,
+    updatedAt
 }: DocumentEditorProps) {
     const { editor, validateContent, getWordCount, getCharacterCount } = useEditor({
         content,
@@ -77,11 +79,18 @@ export function DocumentEditor({
                     )}
                 </div>
 
-                {onAutoSave && (
-                    <span className="text-green-600">
-                        Auto-save enabled
-                    </span>
-                )}
+                <div className="flex items-center gap-4">
+                    {updatedAt && (
+                        <span>
+                            Last updated: {new Date(updatedAt).toLocaleTimeString()}
+                        </span>
+                    )}
+                    {onAutoSave && (
+                        <span className="text-green-600">
+                            Auto-save enabled
+                        </span>
+                    )}
+                </div>
             </div>
 
             {/* Error Display */}

--- a/frontend/components/draft/editors/email-editor.tsx
+++ b/frontend/components/draft/editors/email-editor.tsx
@@ -13,6 +13,7 @@ interface EmailEditorProps {
     placeholder?: string;
     className?: string;
     disabled?: boolean;
+    updatedAt?: string;
 }
 
 export function EmailEditor({
@@ -20,7 +21,8 @@ export function EmailEditor({
     onUpdate,
     onAutoSave,
     className,
-    disabled = false
+    disabled = false,
+    updatedAt
 }: EmailEditorProps) {
     const { editor, validateContent, getWordCount, getCharacterCount } = useEditor({
         content,
@@ -77,11 +79,18 @@ export function EmailEditor({
                     )}
                 </div>
 
-                {onAutoSave && (
-                    <span className="text-green-600">
-                        Auto-save enabled
-                    </span>
-                )}
+                <div className="flex items-center gap-4">
+                    {updatedAt && (
+                        <span>
+                            Last updated: {new Date(updatedAt).toLocaleTimeString()}
+                        </span>
+                    )}
+                    {onAutoSave && (
+                        <span className="text-green-600">
+                            Auto-save enabled
+                        </span>
+                    )}
+                </div>
             </div>
 
             {/* Error Display */}


### PR DESCRIPTION
- Hide "Draft" header when no active draft exists
- Remove "No Draft Selected" text and explanatory content
- Show only draft type buttons (Email, Calendar, Document) in empty state
- Improve UI focus by eliminating unnecessary text elements