### PR TITLE
feat: improve edit meeting poll navigation to return to previous page

### DIFF
--- a/frontend/components/meetings/meeting-poll-edit.tsx
+++ b/frontend/components/meetings/meeting-poll-edit.tsx
@@ -19,7 +19,7 @@ interface MeetingPollEditProps {
 }
 
 export function MeetingPollEdit({ pollId }: MeetingPollEditProps) {
-    const { setMeetingSubView } = useToolStateUtils();
+    const { goBackToPreviousMeetingView } = useToolStateUtils();
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [saving, setSaving] = useState(false);
@@ -55,7 +55,7 @@ export function MeetingPollEdit({ pollId }: MeetingPollEditProps) {
                 duration_minutes: duration,
                 location,
             });
-            setMeetingSubView('view', pollId);
+            goBackToPreviousMeetingView();
         } catch (e: unknown) {
             if (e && typeof e === 'object' && 'message' in e) {
                 setError((e as { message?: string }).message || "Failed to update poll");
@@ -73,7 +73,7 @@ export function MeetingPollEdit({ pollId }: MeetingPollEditProps) {
         setError(null);
         try {
             await gatewayClient.deleteMeetingPoll(pollId);
-            setMeetingSubView('list');
+            goBackToPreviousMeetingView();
         } catch (e: unknown) {
             if (e && typeof e === 'object' && 'message' in e) {
                 setError((e as { message?: string }).message || "Failed to delete poll");
@@ -86,7 +86,7 @@ export function MeetingPollEdit({ pollId }: MeetingPollEditProps) {
     };
 
     const handleCancel = () => {
-        setMeetingSubView('view', pollId);
+        goBackToPreviousMeetingView();
     };
 
     if (loading) {
@@ -109,7 +109,7 @@ export function MeetingPollEdit({ pollId }: MeetingPollEditProps) {
                     className="flex items-center gap-2"
                 >
                     <ArrowLeft className="h-4 w-4" />
-                    Back to Results
+                    Back
                 </Button>
                 <h1 className="text-2xl font-bold">Edit Meeting Poll</h1>
             </div>

--- a/frontend/hooks/use-tool-state.ts
+++ b/frontend/hooks/use-tool-state.ts
@@ -16,6 +16,7 @@ export function useToolStateUtils() {
         setMeetingSubView,
         getMeetingSubView,
         getMeetingPollId,
+        goBackToPreviousMeetingView,
     } = useToolState();
 
     // Get all enabled tools
@@ -123,6 +124,7 @@ export function useToolStateUtils() {
         setMeetingSubView,
         getMeetingSubView,
         getMeetingPollId,
+        goBackToPreviousMeetingView,
 
         // Utility functions
         getEnabledTools,

--- a/frontend/types/navigation.ts
+++ b/frontend/types/navigation.ts
@@ -26,6 +26,8 @@ export interface ToolState {
     // Sub-views for specific tools
     meetingSubView: MeetingSubView;
     meetingPollId: string | null; // For view/edit specific polls
+    previousMeetingSubView: MeetingSubView | null; // Track previous subview for navigation
+    previousMeetingPollId: string | null; // Track previous poll ID for navigation
 }
 
 export interface ToolContextType {
@@ -40,6 +42,8 @@ export interface ToolContextType {
     setMeetingSubView: (subView: MeetingSubView, pollId?: string) => void;
     getMeetingSubView: () => MeetingSubView;
     getMeetingPollId: () => string | null;
+    // Navigation back to previous meeting subview
+    goBackToPreviousMeetingView: () => void;
 }
 
 export interface NavigationItem {


### PR DESCRIPTION
- Add previous meeting subview tracking to ToolState
- Implement goBackToPreviousMeetingView method in tool context
- Update meeting poll edit component to use previous page navigation
- Store current view as previous when navigating to edit mode
- Replace hardcoded "Back to Results" with dynamic "Back" button
- Ensure save, cancel, and delete actions return to previous page
- Maintain backward compatibility and state persistence