### PR TITLE
fix(office): add missing /v1 prefix to internal API endpoints

### DIFF
--- a/services/chat/agents/llm_tools.py
+++ b/services/chat/agents/llm_tools.py
@@ -182,7 +182,7 @@ def get_user_available_providers(user_id: str) -> List[str]:
 
         user_service_url = get_settings().user_management_service_url
         response = requests.get(
-            f"{user_service_url}/internal/users/{user_id}/integrations",
+            f"{user_service_url}/v1/internal/users/{user_id}/integrations",
             headers=headers,
             timeout=5,
         )

--- a/services/demos/chat.py
+++ b/services/demos/chat.py
@@ -338,7 +338,7 @@ class UserServiceClient(ServiceClient):
 
                 # Fallback to internal endpoint
                 response = await client.get(
-                    f"{self.base_url}/internal/users/{self.user_id}/integrations",
+                    f"{self.base_url}/v1/internal/users/{self.user_id}/integrations",
                     headers={"X-API-Key": settings.API_FRONTEND_USER_KEY},
                 )
 
@@ -384,7 +384,7 @@ class UserServiceClient(ServiceClient):
                 # Use the preferences endpoint to check if user exists
                 # This endpoint properly checks the database for user existence
                 response = await client.get(
-                    f"{self.base_url}/internal/users/{user_id}/preferences",
+                    f"{self.base_url}/v1/internal/users/{user_id}/preferences",
                     headers={"X-API-Key": settings.API_FRONTEND_USER_KEY},
                 )
                 if response.status_code == 200:
@@ -419,7 +419,7 @@ class UserServiceClient(ServiceClient):
         try:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.get(
-                    f"{self.base_url}/internal/users/{self.user_id}/preferences",
+                    f"{self.base_url}/v1/internal/users/{self.user_id}/preferences",
                     headers={"X-API-Key": settings.API_FRONTEND_USER_KEY},
                 )
 

--- a/services/demos/manual/nextauth_integration_demo.py
+++ b/services/demos/manual/nextauth_integration_demo.py
@@ -76,7 +76,7 @@ async def test_internal_service() -> bool:
 
         # Test internal preferences
         response = await client.get(
-            "http://localhost:8001/internal/users/google_108234567890123456789/preferences",
+            "http://localhost:8001/v1/internal/users/google_108234567890123456789/preferences",
             headers=headers,
         )
         if response.status_code == 200:

--- a/services/demos/user_management_demo.py
+++ b/services/demos/user_management_demo.py
@@ -536,7 +536,7 @@ class UserManagementDemo:
 
         try:
             response = await self.client.post(
-                f"{self.base_url}/internal/tokens/get",
+                f"{self.base_url}/v1/internal/tokens/get",
                 json=token_request,
                 headers={
                     "X-API-Key": self.service_api_key,

--- a/services/office/core/token_manager.py
+++ b/services/office/core/token_manager.py
@@ -164,7 +164,7 @@ class TokenManager:
             logger.info(f"Requesting token for user {user_id}, provider {provider}")
 
             response = await self.http_client.post(
-                f"{get_settings().USER_MANAGEMENT_SERVICE_URL}/internal/tokens/get",
+                f"{get_settings().USER_MANAGEMENT_SERVICE_URL}/v1/internal/tokens/get",
                 json={
                     "user_id": user_id,
                     "provider": provider,


### PR DESCRIPTION
- Fix token refresh bug where office service couldn't retrieve tokens from user management service
- Update office service token manager to call /v1/internal/tokens/get instead of /internal/tokens/get
- Fix chat service LLM tools to use correct internal endpoint paths
- Update demo files to use proper /v1 prefix for internal endpoints
- Resolves 404 "Endpoint not found" errors when services call internal user management APIs

The user management service mounts internal routers at /v1/internal/ but services were calling /internal/ directly.