### PR TITLE
fix: add missing /v1 prefix to office service API calls

### DIFF
--- a/services/chat/agents/llm_tools.py
+++ b/services/chat/agents/llm_tools.py
@@ -107,7 +107,7 @@ def get_calendar_events(
     try:
         office_service_url = get_settings().office_service_url
         response = requests.get(
-            f"{office_service_url}/calendar/events",
+            f"{office_service_url}/v1/calendar/events",
             headers=headers,
             params=params,
             timeout=10,
@@ -250,7 +250,7 @@ def get_emails(
     try:
         office_service_url = get_settings().office_service_url
         response = requests.get(
-            f"{office_service_url}/email/messages",
+            f"{office_service_url}/v1/email/messages",
             headers=headers,
             params=params,
             timeout=10,
@@ -314,7 +314,7 @@ def get_notes(
     try:
         office_service_url = get_settings().office_service_url
         response = requests.get(
-            f"{office_service_url}/notes",
+            f"{office_service_url}/v1/notes",
             headers=headers,
             params=params,
             timeout=10,
@@ -377,7 +377,7 @@ def get_documents(
     try:
         office_service_url = get_settings().office_service_url
         response = requests.get(
-            f"{office_service_url}/documents",
+            f"{office_service_url}/v1/files",
             headers=headers,
             params=params,
             timeout=10,

--- a/services/meetings/services/calendar_integration.py
+++ b/services/meetings/services/calendar_integration.py
@@ -10,7 +10,7 @@ API_KEY = os.environ.get("API_FRONTEND_OFFICE_KEY", "test-office-key")
 async def get_user_availability(
     user_id: str, start: str, end: str, duration: int
 ) -> dict:
-    url = f"{OFFICE_SERVICE_URL}/calendar/availability"
+    url = f"{OFFICE_SERVICE_URL}/v1/calendar/availability"
     headers = {"X-API-Key": API_KEY, "X-User-Id": user_id}
     params = {"start": start, "end": end, "duration": str(duration)}
     async with httpx.AsyncClient() as client:
@@ -22,7 +22,7 @@ async def get_user_availability(
 async def create_calendar_event(
     user_id: str, poll_id: str, selected_slot_id: str, participants: List[str]
 ) -> dict:
-    url = f"{OFFICE_SERVICE_URL}/calendar/create-meeting"
+    url = f"{OFFICE_SERVICE_URL}/v1/calendar/create-meeting"
     headers = {"X-API-Key": API_KEY, "X-User-Id": user_id}
     data = {
         "pollId": poll_id,

--- a/services/meetings/services/email_integration.py
+++ b/services/meetings/services/email_integration.py
@@ -10,7 +10,7 @@ API_KEY = os.environ.get("API_FRONTEND_OFFICE_KEY", "test-office-key")
 async def send_invitation_email(
     to_email: str, subject: str, body: str, user_id: str, provider: Optional[str] = None
 ) -> dict:
-    url = f"{OFFICE_SERVICE_URL}/email/send"
+    url = f"{OFFICE_SERVICE_URL}/v1/email/send"
     headers = {"X-API-Key": API_KEY, "X-User-Id": user_id}
     data = {
         "to": [{"email": to_email}],


### PR DESCRIPTION
- Fix 404 errors in meetings service email integration
- Fix 404 errors in meetings service calendar integration
- Fix 404 errors in chat service LLM tools
- Update all office service endpoints to use /v1 prefix

The office service mounts all routers with /v1 prefix, but several services were calling endpoints without this prefix, causing 404 errors when trying to send meeting invitations and access calendar/email data.

Fixes: Client error '404 Not Found' for url 'http://localhost:8003/email/send'