### PR TITLE
feat(chat): add validation alias for user management service URL

### DIFF
--- a/services/chat/settings.py
+++ b/services/chat/settings.py
@@ -55,7 +55,9 @@ class Settings(BaseSettings):
     user_management_service_url: str = Field(
         ...,
         description="User management service URL",
-        validation_alias=AliasChoices("USER_SERVICE_URL", "USER_MANAGEMENT_SERVICE_URL"),
+        validation_alias=AliasChoices(
+            "USER_SERVICE_URL", "USER_MANAGEMENT_SERVICE_URL"
+        ),
     )
     office_service_url: str = Field(
         default=...,

--- a/services/chat/settings.py
+++ b/services/chat/settings.py
@@ -55,6 +55,7 @@ class Settings(BaseSettings):
     user_management_service_url: str = Field(
         ...,
         description="User management service URL",
+        validation_alias=AliasChoices("USER_SERVICE_URL", "USER_MANAGEMENT_SERVICE_URL"),
     )
     office_service_url: str = Field(
         default=...,


### PR DESCRIPTION
Add AliasChoices validation to user_management_service_url field to support both USER_SERVICE_URL and USER_MANAGEMENT_SERVICE_URL environment variables. This provides backward compatibility for existing deployments while allowing the more descriptive variable name.