### PR TITLE
feat(meetings): persist user selections in poll response page

### DIFF
--- a/frontend/app/public/meetings/respond/[response_token]/page.tsx
+++ b/frontend/app/public/meetings/respond/[response_token]/page.tsx
@@ -55,7 +55,7 @@ export default function PollResponsePage() {
                 // Initialize responses for all time slots
                 const initialResponses = data.poll.time_slots.map((slot: TimeSlot) => {
                     // Check if there's an existing response for this time slot
-                    const existingResponse = data.responses?.find((r: any) => r.time_slot_id === slot.id);
+                    const existingResponse = data.responses?.find((r: { time_slot_id: string; response: string; comment?: string }) => r.time_slot_id === slot.id);
 
                     if (existingResponse) {
                         // Use existing response

--- a/services/meetings/api/public.py
+++ b/services/meetings/api/public.py
@@ -41,9 +41,7 @@ def get_poll_by_response_token(response_token: str) -> dict:
         # Convert to the format expected by frontend
         responses = []
         for resp in existing_responses:
-            comment_value = ""
-            if resp.comment is not None:
-                comment_value = resp.comment
+            comment_value = str(resp.comment) if resp.comment is not None else ""
             responses.append(
                 {
                     "time_slot_id": str(resp.time_slot_id),

--- a/services/meetings/api/public.py
+++ b/services/meetings/api/public.py
@@ -31,6 +31,27 @@ def get_poll_by_response_token(response_token: str) -> dict:
         if not poll:
             raise HTTPException(status_code=404, detail="Poll not found")
 
+        # Get existing responses for this participant
+        existing_responses = (
+            session.query(PollResponseModel)
+            .filter_by(participant_id=participant.id)
+            .all()
+        )
+
+        # Convert to the format expected by frontend
+        responses = []
+        for resp in existing_responses:
+            comment_value = ""
+            if resp.comment is not None:
+                comment_value = resp.comment
+            responses.append(
+                {
+                    "time_slot_id": str(resp.time_slot_id),
+                    "response": resp.response.value,
+                    "comment": comment_value,
+                }
+            )
+
         return {
             "poll": MeetingPoll.model_validate(poll),
             "participant": {
@@ -39,6 +60,7 @@ def get_poll_by_response_token(response_token: str) -> dict:
                 "name": participant.name,
                 "status": participant.status.value,
             },
+            "responses": responses,
         }
 
 


### PR DESCRIPTION
- Add existing responses to GET /response/{token} endpoint
- Restore user selections on page reload instead of defaulting to unavailable
- Auto-expand comment sections that have existing content
- Show "(has content)" indicator for collapsed comments with text
- Improve UX by allowing users to edit responses without losing work

Backend changes:
- Query and return existing PollResponse records for participant
- Include responses array in API response with time_slot_id, response, and comment

Frontend changes:
- Check for existing responses when loading poll data
- Restore previous selections and comments on page load
- Auto-expand comment sections with content
- Maintain backward compatibility for new responses