### PR TITLE
feat(meetings): include poll responses in get_poll API endpoint

### DIFF
--- a/frontend/components/meetings/meeting-poll-results.tsx
+++ b/frontend/components/meetings/meeting-poll-results.tsx
@@ -27,7 +27,15 @@ interface Poll {
     location?: string;
     participants: Participant[];
     time_slots: TimeSlot[];
-    responses?: Array<{ time_slot_id: string; response: string }>;
+    responses?: Array<{
+        id: string;
+        participant_id: string;
+        time_slot_id: string;
+        response: string;
+        comment?: string;
+        created_at: string;
+        updated_at: string;
+    }>;
 }
 
 function getSlotStats(poll: Poll) {

--- a/services/meetings/schemas/__init__.py
+++ b/services/meetings/schemas/__init__.py
@@ -175,6 +175,7 @@ class MeetingPoll(MeetingPollBase):
     poll_token: str
     time_slots: List[TimeSlot]
     participants: List[PollParticipant]
+    responses: Optional[List[PollResponse]] = None
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/services/meetings/tests/test_poll_creation.py
+++ b/services/meetings/tests/test_poll_creation.py
@@ -101,3 +101,49 @@ class TestPollCreation(BaseMeetingsTest):
         )
         assert resp2.status_code == 200, resp2.text
         assert resp2.json()["ok"] is True
+
+    def test_get_poll_includes_responses(self, poll_payload):
+        user_id = str(uuid4())
+        # Create poll
+        resp = client.post(
+            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        poll_id = data["id"]
+
+        # Submit a response
+        participant = data["participants"][0]
+        response_token = participant["response_token"]
+        response_payload = {
+            "responses": [
+                {
+                    "time_slot_id": data["time_slots"][0]["id"],
+                    "response": "available",
+                    "comment": "Works for me!",
+                }
+            ]
+        }
+        resp2 = client.put(
+            f"/api/v1/public/polls/response/{response_token}",
+            json=response_payload,
+        )
+        assert resp2.status_code == 200, resp2.text
+
+        # Get the poll and verify responses are included
+        resp3 = client.get(
+            f"/api/v1/meetings/polls/{poll_id}", headers={"X-User-Id": user_id}
+        )
+        assert resp3.status_code == 200, resp3.text
+        poll_data = resp3.json()
+
+        # Verify responses field is present and contains the submitted response
+        assert "responses" in poll_data
+        assert len(poll_data["responses"]) == 1
+        response = poll_data["responses"][0]
+        assert response["time_slot_id"] == data["time_slots"][0]["id"]
+        assert response["response"] == "available"
+        assert response["comment"] == "Works for me!"
+        assert "participant_id" in response
+        assert "created_at" in response
+        assert "updated_at" in response


### PR DESCRIPTION
- Add responses field to MeetingPoll schema to include poll response data
- Update get_poll API endpoint to fetch and return poll responses
- Update frontend Poll interface to handle backend response structure
- Add test to verify responses are included in API response

Fixes issue where Time Slot Popularity section showed zero values despite participants having submitted responses.