### PR TITLE
feat: add resend invitation endpoint for meeting poll participants

### DIFF
--- a/frontend/components/meetings/meeting-poll-results.tsx
+++ b/frontend/components/meetings/meeting-poll-results.tsx
@@ -248,7 +248,7 @@ export function MeetingPollResults({ pollId }: MeetingPollResultsProps) {
         }
     };
 
-    const handleResendEmail = async (participantId: string, email: string) => {
+    const handleResendEmail = async (participantId: string) => {
         if (!pollId) return;
 
         setResendingEmails(prev => new Set(prev).add(participantId));

--- a/frontend/components/meetings/meeting-poll-results.tsx
+++ b/frontend/components/meetings/meeting-poll-results.tsx
@@ -380,7 +380,7 @@ export function MeetingPollResults({ pollId }: MeetingPollResultsProps) {
                                                             <Button
                                                                 variant="ghost"
                                                                 size="sm"
-                                                                onClick={() => handleResendEmail(participant.id, participant.email)}
+                                                                onClick={() => handleResendEmail(participant.id)}
                                                                 disabled={resendingEmails.has(participant.id)}
                                                                 className="flex items-center gap-1"
                                                             >

--- a/frontend/lib/gateway-client.ts
+++ b/frontend/lib/gateway-client.ts
@@ -343,6 +343,12 @@ export class GatewayClient {
             method: 'POST',
         });
     }
+
+    async resendMeetingInvitation(pollId: string, participantId: string): Promise<void> {
+        return this.request<void>(`/api/v1/meetings/polls/${pollId}/participants/${participantId}/resend-invitation`, {
+            method: 'POST',
+        });
+    }
 }
 
 // Export singleton instance

--- a/services/meetings/settings.py
+++ b/services/meetings/settings.py
@@ -37,6 +37,12 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("API_MEETINGS_USER_KEY"),
     )
 
+    api_frontend_meetings_key: str = Field(
+        default=...,  # required
+        description="Frontend API key to access meetings service",
+        validation_alias=AliasChoices("API_FRONTEND_MEETINGS_KEY"),
+    )
+
     office_service_url: str = Field(
         default=...,
         description="URL for the office service",

--- a/services/meetings/tests/test_base.py
+++ b/services/meetings/tests/test_base.py
@@ -22,6 +22,7 @@ class BaseMeetingsTest:
         os.environ["API_EMAIL_SYNC_MEETINGS_KEY"] = "test-email-sync-key"
         os.environ["API_MEETINGS_OFFICE_KEY"] = "test-meetings-office-key"
         os.environ["API_MEETINGS_USER_KEY"] = "test-meetings-user-key"
+        os.environ["API_FRONTEND_MEETINGS_KEY"] = "test-frontend-meetings-key"
 
         # Optional environment variables with test defaults
         os.environ.setdefault("OFFICE_SERVICE_URL", "http://localhost:8003")

--- a/services/meetings/tests/test_resend_invitation.py
+++ b/services/meetings/tests/test_resend_invitation.py
@@ -1,0 +1,189 @@
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.meetings.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_poll():
+    return {
+        "id": str(uuid4()),
+        "user_id": "test-user-123",
+        "title": "Test Meeting",
+        "description": "Test meeting description",
+        "duration_minutes": 60,
+        "status": "active",
+        "poll_token": "test-token-123",
+    }
+
+
+@pytest.fixture
+def mock_participant():
+    return {
+        "id": str(uuid4()),
+        "poll_id": str(uuid4()),
+        "email": "test@example.com",
+        "name": "Test User",
+        "status": "pending",
+        "reminder_sent_count": 0,
+        "response_token": "participant-token-123",
+    }
+
+
+class TestResendInvitation:
+    """Test cases for the resend invitation endpoint."""
+
+    @patch("services.meetings.api.polls.email_integration.send_invitation_email")
+    @patch("services.meetings.api.polls.get_session")
+    def test_resend_invitation_success(
+        self, mock_get_session, mock_send_email, client, mock_poll, mock_participant
+    ):
+        """Test successful resend of invitation email."""
+        # Mock the database session
+        mock_session = AsyncMock()
+        mock_get_session.return_value.__enter__.return_value = mock_session
+
+        # Mock poll query
+        mock_poll_obj = type("MockPoll", (), mock_poll)()
+        mock_session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_poll_obj
+        )
+
+        # Mock participant query
+        mock_participant_obj = type("MockParticipant", (), mock_participant)()
+        mock_session.query.return_value.filter_by.return_value.first.side_effect = [
+            mock_poll_obj,  # First call for poll
+            mock_participant_obj,  # Second call for participant
+        ]
+
+        # Mock email sending
+        mock_send_email.return_value = {"ok": True}
+
+        # Make the request
+        response = client.post(
+            f"/api/v1/meetings/polls/{mock_poll['id']}/participants/{mock_participant['id']}/resend-invitation",
+            headers={"X-User-Id": mock_poll["user_id"]},
+        )
+
+        # Verify response
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ok"] is True
+        assert data["message"] == "Invitation resent successfully"
+        assert data["participant_email"] == mock_participant["email"]
+        assert data["reminder_count"] == 1
+
+        # Verify email was sent
+        mock_send_email.assert_called_once()
+
+        # Verify participant was updated
+        assert mock_participant_obj.reminder_sent_count == 1
+        mock_session.commit.assert_called_once()
+
+    @patch("services.meetings.api.polls.get_session")
+    def test_resend_invitation_poll_not_found(self, mock_get_session, client):
+        """Test resend invitation when poll doesn't exist."""
+        # Mock empty poll query
+        mock_session = AsyncMock()
+        mock_get_session.return_value.__enter__.return_value = mock_session
+        mock_session.query.return_value.filter_by.return_value.first.return_value = None
+
+        response = client.post(
+            f"/api/v1/meetings/polls/{uuid4()}/participants/{uuid4()}/resend-invitation",
+            headers={"X-User-Id": "test-user"},
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Poll not found"
+
+    @patch("services.meetings.api.polls.get_session")
+    def test_resend_invitation_unauthorized(self, mock_get_session, client, mock_poll):
+        """Test resend invitation when user doesn't own the poll."""
+        # Mock poll query with different user
+        mock_poll_obj = type("MockPoll", (), mock_poll)()
+        mock_session = AsyncMock()
+        mock_get_session.return_value.__enter__.return_value = mock_session
+        mock_session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_poll_obj
+        )
+
+        response = client.post(
+            f"/api/v1/meetings/polls/{mock_poll['id']}/participants/{uuid4()}/resend-invitation",
+            headers={"X-User-Id": "different-user"},
+        )
+
+        assert response.status_code == 403
+        assert "Not authorized" in response.json()["detail"]
+
+    @patch("services.meetings.api.polls.get_session")
+    def test_resend_invitation_participant_not_found(
+        self, mock_get_session, client, mock_poll, mock_participant
+    ):
+        """Test resend invitation when participant doesn't exist."""
+        # Mock poll query
+        mock_poll_obj = type("MockPoll", (), mock_poll)()
+        mock_session = AsyncMock()
+        mock_get_session.return_value.__enter__.return_value = mock_session
+        mock_session.query.return_value.filter_by.return_value.first.side_effect = [
+            mock_poll_obj,  # First call for poll
+            None,  # Second call for participant (not found)
+        ]
+
+        response = client.post(
+            f"/api/v1/meetings/polls/{mock_poll['id']}/participants/{mock_participant['id']}/resend-invitation",
+            headers={"X-User-Id": mock_poll["user_id"]},
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Participant not found"
+
+    @patch("services.meetings.api.polls.email_integration.send_invitation_email")
+    @patch("services.meetings.api.polls.get_session")
+    def test_resend_invitation_email_failure(
+        self, mock_get_session, mock_send_email, client, mock_poll, mock_participant
+    ):
+        """Test resend invitation when email sending fails."""
+        # Mock the database session
+        mock_session = AsyncMock()
+        mock_get_session.return_value.__enter__.return_value = mock_session
+
+        # Mock poll query
+        mock_poll_obj = type("MockPoll", (), mock_poll)()
+        mock_session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_poll_obj
+        )
+
+        # Mock participant query
+        mock_participant_obj = type("MockParticipant", (), mock_participant)()
+        mock_session.query.return_value.filter_by.return_value.first.side_effect = [
+            mock_poll_obj,  # First call for poll
+            mock_participant_obj,  # Second call for participant
+        ]
+
+        # Mock email sending failure
+        mock_send_email.side_effect = ValueError("Email service unavailable")
+
+        response = client.post(
+            f"/api/v1/meetings/polls/{mock_poll['id']}/participants/{mock_participant['id']}/resend-invitation",
+            headers={"X-User-Id": mock_poll["user_id"]},
+        )
+
+        assert response.status_code == 400
+        assert "Failed to resend invitation" in response.json()["detail"]
+
+    def test_resend_invitation_missing_user_id(self, client):
+        """Test resend invitation without user ID header."""
+        response = client.post(
+            f"/api/v1/meetings/polls/{uuid4()}/participants/{uuid4()}/resend-invitation",
+        )
+
+        assert response.status_code == 400
+        assert "Missing X-User-Id header" in response.json()["detail"]


### PR DESCRIPTION
- Add POST /api/v1/meetings/polls/{poll_id}/participants/{participant_id}/resend-invitation endpoint
- Implement email resend functionality with proper authorization checks
- Add comprehensive error handling and logging
- Update participant reminder_sent_count on successful resend
- Add frontend integration with loading states and error handling
- Create test suite covering success and error scenarios
- Update gateway client with resendMeetingInvitation method
- Enhance meeting poll results UI with expandable participant details
- Add email addresses to time slot response details
- Change "Time Slot Popularity" to "Time Slots" for better UX