### PR TITLE
feat: add API key authentication to meetings service endpoints

### DIFF
--- a/services/meetings/tests/test_email_response.py
+++ b/services/meetings/tests/test_email_response.py
@@ -36,52 +36,51 @@ class TestEmailResponse(BaseMeetingsTest):
         models.get_engine = lambda: models._test_engine
         Base.metadata.create_all(models._test_engine)
 
+    def create_poll_and_participant(self):
+        now = datetime.utcnow()
+        poll_id = uuid4()
+        slot_id = uuid4()
+        poll_token = uuid4().hex
+        with get_session() as session:
+            poll = MeetingPoll(
+                id=poll_id,
+                user_id="user-1",
+                title="Email Poll",
+                description="Test poll for email response",
+                duration_minutes=30,
+                location="Test Room",
+                meeting_type="virtual",
+                status="active",
+                response_deadline=now + timedelta(days=2),
+                poll_token=poll_token,
+            )
+            session.add(poll)
+            # Add a time slot
+            from services.meetings.models.meeting import TimeSlot
 
-def create_poll_and_participant():
-    now = datetime.utcnow()
-    poll_id = uuid4()
-    slot_id = uuid4()
-    poll_token = uuid4().hex
-    with get_session() as session:
-        poll = MeetingPoll(
-            id=poll_id,
-            user_id="user-1",
-            title="Email Poll",
-            description="Test poll for email response",
-            duration_minutes=30,
-            location="Test Room",
-            meeting_type="virtual",
-            status="active",
-            response_deadline=now + timedelta(days=2),
-            poll_token=poll_token,
-        )
-        session.add(poll)
-        # Add a time slot
-        from services.meetings.models.meeting import TimeSlot
-
-        slot = TimeSlot(
-            id=slot_id,
-            poll_id=poll_id,
-            start_time=now + timedelta(days=3),
-            end_time=now + timedelta(days=3, minutes=30),
-            timezone="UTC",
-        )
-        session.add(slot)
-        # Add a participant
-        participant = PollParticipant(
-            id=uuid4(),
-            poll_id=poll_id,
-            email="alice@example.com",
-            name="Alice",
-            status="pending",
-            response_token=uuid4().hex,
-        )
-        session.add(participant)
-        session.commit()
-        return poll, slot, participant
+            slot = TimeSlot(
+                id=slot_id,
+                poll_id=poll_id,
+                start_time=now + timedelta(days=3),
+                end_time=now + timedelta(days=3, minutes=30),
+                timezone="UTC",
+            )
+            session.add(slot)
+            # Add a participant
+            participant = PollParticipant(
+                id=uuid4(),
+                poll_id=poll_id,
+                email="alice@example.com",
+                name="Alice",
+                status="pending",
+                response_token=uuid4().hex,
+            )
+            session.add(participant)
+            session.commit()
+            return poll, slot, participant
 
     def test_process_email_response_success(self):
-        poll, slot, participant = create_poll_and_participant()
+        poll, slot, participant = self.create_poll_and_participant()
         payload = {
             "emailId": "irrelevant",
             "content": "RESPONSE: available Looking forward to it!",
@@ -116,7 +115,7 @@ def create_poll_and_participant():
             assert any(r.response == ResponseType.available for r in responses)
 
     def test_process_email_response_invalid_key(self):
-        poll, slot, participant = create_poll_and_participant()
+        poll, slot, participant = self.create_poll_and_participant()
         payload = {
             "emailId": "irrelevant",
             "content": "RESPONSE: available",
@@ -130,7 +129,7 @@ def create_poll_and_participant():
         assert resp.status_code == 401
 
     def test_process_email_response_unparseable_content(self):
-        poll, slot, participant = create_poll_and_participant()
+        poll, slot, participant = self.create_poll_and_participant()
         payload = {
             "emailId": "irrelevant",
             "content": "I am not following the format",
@@ -145,7 +144,7 @@ def create_poll_and_participant():
         assert "Could not parse response" in resp.text
 
     def test_process_email_response_unknown_sender(self):
-        poll, slot, participant = create_poll_and_participant()
+        poll, slot, participant = self.create_poll_and_participant()
         payload = {
             "emailId": "irrelevant",
             "content": "RESPONSE: available",

--- a/services/meetings/tests/test_poll_authorization.py
+++ b/services/meetings/tests/test_poll_authorization.py
@@ -64,7 +64,9 @@ class TestPollAuthorization(BaseMeetingsTest):
 
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -72,7 +74,8 @@ class TestPollAuthorization(BaseMeetingsTest):
 
         # Delete poll with same user
         resp = client.delete(
-            f"/api/v1/meetings/polls/{poll_id}", headers={"X-User-Id": user_id}
+            f"/api/v1/meetings/polls/{poll_id}",
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         assert resp.json() == {"ok": True}
@@ -86,7 +89,7 @@ class TestPollAuthorization(BaseMeetingsTest):
         resp = client.post(
             "/api/v1/meetings/polls/",
             json=poll_payload,
-            headers={"X-User-Id": user_id_1},
+            headers={"X-User-Id": user_id_1, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -94,7 +97,8 @@ class TestPollAuthorization(BaseMeetingsTest):
 
         # Try to delete poll with user 2
         resp = client.delete(
-            f"/api/v1/meetings/polls/{poll_id}", headers={"X-User-Id": user_id_2}
+            f"/api/v1/meetings/polls/{poll_id}",
+            headers={"X-User-Id": user_id_2, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 403, resp.text
         assert "Not authorized to delete this poll" in resp.text
@@ -105,7 +109,9 @@ class TestPollAuthorization(BaseMeetingsTest):
 
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -116,7 +122,7 @@ class TestPollAuthorization(BaseMeetingsTest):
         resp = client.put(
             f"/api/v1/meetings/polls/{poll_id}",
             json=update_payload,
-            headers={"X-User-Id": user_id},
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         updated_data = resp.json()
@@ -131,7 +137,7 @@ class TestPollAuthorization(BaseMeetingsTest):
         resp = client.post(
             "/api/v1/meetings/polls/",
             json=poll_payload,
-            headers={"X-User-Id": user_id_1},
+            headers={"X-User-Id": user_id_1, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -142,7 +148,7 @@ class TestPollAuthorization(BaseMeetingsTest):
         resp = client.put(
             f"/api/v1/meetings/polls/{poll_id}",
             json=update_payload,
-            headers={"X-User-Id": user_id_2},
+            headers={"X-User-Id": user_id_2, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 403, resp.text
         assert "Not authorized to update this poll" in resp.text
@@ -153,14 +159,19 @@ class TestPollAuthorization(BaseMeetingsTest):
 
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
         poll_id = data["id"]
 
         # Try to delete poll without user ID header
-        resp = client.delete(f"/api/v1/meetings/polls/{poll_id}")
+        resp = client.delete(
+            f"/api/v1/meetings/polls/{poll_id}",
+            headers={"X-API-Key": "test-frontend-meetings-key"},
+        )
         assert resp.status_code == 400, resp.text
         assert "Missing X-User-Id header" in resp.text
 
@@ -170,7 +181,8 @@ class TestPollAuthorization(BaseMeetingsTest):
         fake_poll_id = str(uuid4())
 
         resp = client.delete(
-            f"/api/v1/meetings/polls/{fake_poll_id}", headers={"X-User-Id": user_id}
+            f"/api/v1/meetings/polls/{fake_poll_id}",
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 404, resp.text
         assert "Poll not found" in resp.text
@@ -182,7 +194,9 @@ class TestPollAuthorization(BaseMeetingsTest):
 
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -193,7 +207,8 @@ class TestPollAuthorization(BaseMeetingsTest):
 
         # Delete poll with same user ID
         resp = client.delete(
-            f"/api/v1/meetings/polls/{poll_id}", headers={"X-User-Id": user_id}
+            f"/api/v1/meetings/polls/{poll_id}",
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         assert resp.json() == {"ok": True}
@@ -204,7 +219,9 @@ class TestPollAuthorization(BaseMeetingsTest):
 
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -214,7 +231,10 @@ class TestPollAuthorization(BaseMeetingsTest):
         different_user_id = "AAAAAAAAAAAAAAAAAAAAAG_WiRzTkk4vuAr97CA2Dc5"
         resp = client.delete(
             f"/api/v1/meetings/polls/{poll_id}",
-            headers={"X-User-Id": different_user_id},
+            headers={
+                "X-User-Id": different_user_id,
+                "X-API-Key": "test-frontend-meetings-key",
+            },
         )
         assert resp.status_code == 403, resp.text
         assert "Not authorized to delete this poll" in resp.text

--- a/services/meetings/tests/test_poll_creation.py
+++ b/services/meetings/tests/test_poll_creation.py
@@ -61,7 +61,9 @@ class TestPollCreation(BaseMeetingsTest):
     def test_create_poll_sets_user_id(self, poll_payload):
         user_id = str(uuid4())
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -70,7 +72,11 @@ class TestPollCreation(BaseMeetingsTest):
         assert data["participants"][0]["email"] == "alice@example.com"
 
     def test_create_poll_missing_user_id_returns_400(self, poll_payload):
-        resp = client.post("/api/v1/meetings/polls/", json=poll_payload)
+        resp = client.post(
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-API-Key": "test-frontend-meetings-key"},
+        )
         assert resp.status_code == 400
         assert "Missing X-User-Id header" in resp.text
 
@@ -78,7 +84,9 @@ class TestPollCreation(BaseMeetingsTest):
         user_id = str(uuid4())
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -106,7 +114,9 @@ class TestPollCreation(BaseMeetingsTest):
         user_id = str(uuid4())
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -132,7 +142,8 @@ class TestPollCreation(BaseMeetingsTest):
 
         # Get the poll and verify responses are included
         resp3 = client.get(
-            f"/api/v1/meetings/polls/{poll_id}", headers={"X-User-Id": user_id}
+            f"/api/v1/meetings/polls/{poll_id}",
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp3.status_code == 200, resp3.text
         poll_data = resp3.json()

--- a/services/meetings/tests/test_security_fixes.py
+++ b/services/meetings/tests/test_security_fixes.py
@@ -64,7 +64,9 @@ class TestSecurityFixes(BaseMeetingsTest):
 
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -80,7 +82,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         resp = client.post(
             f"/api/v1/meetings/polls/{poll_id}/slots/",
             json=slot_payload,
-            headers={"X-User-Id": user_id},
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
 
@@ -93,7 +95,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         resp = client.post(
             "/api/v1/meetings/polls/",
             json=poll_payload,
-            headers={"X-User-Id": user_id_1},
+            headers={"X-User-Id": user_id_1, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -109,7 +111,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         resp = client.post(
             f"/api/v1/meetings/polls/{poll_id}/slots/",
             json=slot_payload,
-            headers={"X-User-Id": user_id_2},
+            headers={"X-User-Id": user_id_2, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 403, resp.text
         assert "Not authorized to modify this poll" in resp.text
@@ -120,7 +122,9 @@ class TestSecurityFixes(BaseMeetingsTest):
 
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -137,7 +141,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         resp = client.put(
             f"/api/v1/meetings/polls/{poll_id}/slots/{slot_id}",
             json=slot_payload,
-            headers={"X-User-Id": user_id},
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
 
@@ -150,7 +154,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         resp = client.post(
             "/api/v1/meetings/polls/",
             json=poll_payload,
-            headers={"X-User-Id": user_id_1},
+            headers={"X-User-Id": user_id_1, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -167,7 +171,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         resp = client.put(
             f"/api/v1/meetings/polls/{poll_id}/slots/{slot_id}",
             json=slot_payload,
-            headers={"X-User-Id": user_id_2},
+            headers={"X-User-Id": user_id_2, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 403, resp.text
         assert "Not authorized to modify this poll" in resp.text
@@ -178,7 +182,9 @@ class TestSecurityFixes(BaseMeetingsTest):
 
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -188,7 +194,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         # Delete time slot
         resp = client.delete(
             f"/api/v1/meetings/polls/{poll_id}/slots/{slot_id}",
-            headers={"X-User-Id": user_id},
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
 
@@ -201,7 +207,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         resp = client.post(
             "/api/v1/meetings/polls/",
             json=poll_payload,
-            headers={"X-User-Id": user_id_1},
+            headers={"X-User-Id": user_id_1, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -211,7 +217,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         # Try to delete time slot with user 2
         resp = client.delete(
             f"/api/v1/meetings/polls/{poll_id}/slots/{slot_id}",
-            headers={"X-User-Id": user_id_2},
+            headers={"X-User-Id": user_id_2, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 403, resp.text
         assert "Not authorized to modify this poll" in resp.text
@@ -222,7 +228,9 @@ class TestSecurityFixes(BaseMeetingsTest):
 
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -231,7 +239,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         # Send invitations
         resp = client.post(
             f"/api/v1/meetings/polls/{poll_id}/send-invitations/",
-            headers={"X-User-Id": user_id},
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         # Should succeed (though email sending might fail in test environment)
         assert resp.status_code in [200, 400], resp.text
@@ -245,7 +253,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         resp = client.post(
             "/api/v1/meetings/polls/",
             json=poll_payload,
-            headers={"X-User-Id": user_id_1},
+            headers={"X-User-Id": user_id_1, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -254,7 +262,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         # Try to send invitations with user 2
         resp = client.post(
             f"/api/v1/meetings/polls/{poll_id}/send-invitations/",
-            headers={"X-User-Id": user_id_2},
+            headers={"X-User-Id": user_id_2, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 403, resp.text
         assert "Not authorized to send invitations for this poll" in resp.text
@@ -265,7 +273,9 @@ class TestSecurityFixes(BaseMeetingsTest):
 
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -281,6 +291,7 @@ class TestSecurityFixes(BaseMeetingsTest):
         resp = client.post(
             f"/api/v1/meetings/polls/{poll_id}/slots/",
             json=slot_payload,
+            headers={"X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 400, resp.text
         assert "Missing X-User-Id header" in resp.text
@@ -291,13 +302,18 @@ class TestSecurityFixes(BaseMeetingsTest):
 
         # Create poll
         resp = client.post(
-            "/api/v1/meetings/polls/", json=poll_payload, headers={"X-User-Id": user_id}
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
         poll_id = data["id"]
 
         # Try to send invitations without user ID header
-        resp = client.post(f"/api/v1/meetings/polls/{poll_id}/send-invitations/")
+        resp = client.post(
+            f"/api/v1/meetings/polls/{poll_id}/send-invitations/",
+            headers={"X-API-Key": "test-frontend-meetings-key"},
+        )
         assert resp.status_code == 400, resp.text
         assert "Missing X-User-Id header" in resp.text


### PR DESCRIPTION
- Add API key auth dependency to all endpoints in slots.py, invitations.py, and email.py
- Implement verify_api_key_auth function with appropriate permissions for each service
- Update test files to include required API key headers
- Fix linter errors for SQLAlchemy Column object handling
- Ensure comprehensive test coverage for authentication scenarios

Endpoints updated:
- slots.py: add_slot, update_slot, delete_slot
- invitations.py: send_invitations
- email.py: process_email_response (updated to use dependency pattern)