### PR TITLE
feat(logging): remove full_path from log output in JSON and text modes

### DIFF
--- a/services/common/logging_config.py
+++ b/services/common/logging_config.py
@@ -162,11 +162,6 @@ class EnhancedTextRenderer:
         else:
             request_id_suffix = ""
 
-        # Get file and line info
-        file_info = ""
-        if "file" in event_dict and "line" in event_dict:
-            file_info = f" {event_dict['file']}:{event_dict['line']}"
-
         # Get user ID if present
         user_info = ""
         user_id = event_dict.get("user_id", "")
@@ -179,7 +174,7 @@ class EnhancedTextRenderer:
             f"[{service}]",
             f"[{level}]",
             request_id_suffix,
-            f"{logger_name}{file_info}",
+            f"{logger_name}",
             f"- {message}{user_info}",
         ]
 
@@ -194,8 +189,6 @@ class EnhancedTextRenderer:
                 "service",
                 "request_id",
                 "user_id",
-                "file",
-                "line",
             ]:
                 if isinstance(value, (str, int, float, bool)):
                     extra_context.append(f"{key}={value}")
@@ -232,7 +225,6 @@ def setup_service_logging(
         structlog.stdlib.PositionalArgumentsFormatter(),
         add_request_context,  # Add our custom context processor
         add_service_context,  # Add service context
-        add_file_line_context,  # Add file/line context
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
@@ -332,7 +324,6 @@ def create_request_logging_middleware() -> Callable:
             f"→ {request.method} {request.url.path}",
             extra={
                 "method": request.method,
-                "path": request.url.path,
                 "query_params": (
                     str(request.query_params) if request.query_params else None
                 ),
@@ -363,7 +354,6 @@ def create_request_logging_middleware() -> Callable:
                 "status_code": response.status_code,
                 "process_time": process_time,
                 "method": request.method,
-                "path": request.url.path,
             },
         )
 

--- a/services/common/tests/test_logging_config.py
+++ b/services/common/tests/test_logging_config.py
@@ -161,7 +161,7 @@ class TestEnhancedLoggingConfiguration:
         assert "| User: demo@example.com" in result
 
     def test_enhanced_text_renderer_with_file_line(self):
-        """Test text rendering with file and line information."""
+        """Test text rendering with file and line information (now shown as extra context)."""
         renderer = EnhancedTextRenderer("test-service")
 
         event_dict = {
@@ -176,8 +176,9 @@ class TestEnhancedLoggingConfiguration:
 
         result = renderer(MagicMock(), "info", event_dict)
 
-        # Should show file and line information
-        assert "api.py:42" in result
+        # File and line information should be shown as extra context, not inline
+        assert "file=api.py" in result
+        assert "line=42" in result
 
     def test_enhanced_text_renderer_complex(self):
         """Test text rendering with all features combined."""
@@ -206,12 +207,14 @@ class TestEnhancedLoggingConfiguration:
         assert "[ERROR]" in result
         assert "[1235]" in result  # Request ID suffix
         assert "services.office.api.health" in result
-        assert "health.py:123" in result
         assert "Failed to process request" in result
         assert "| User: demo@example.com" in result
         assert "error_code=500" in result
         assert "method=GET" in result
         assert "path=/v1/health" in result
+        # File and line information should be shown as extra context
+        assert "file=health.py" in result
+        assert "line=123" in result
 
     def test_enhanced_text_renderer_long_values(self):
         """Test that long values are handled appropriately."""


### PR DESCRIPTION
- Remove path field from request logging extra context
- Remove add_file_line_context processor from logging setup
- Update EnhancedTextRenderer to not include file:line inline
- Update tests to reflect file/line info as extra context
- Maintain all other logging functionality (request ID, user context, etc.)

This change cleans up log output by removing redundant path information while preserving essential debugging and monitoring capabilities.