### PR TITLE
feat(meetings): add separate edit buttons for poll management

### DIFF
--- a/frontend/lib/gateway-client.ts
+++ b/frontend/lib/gateway-client.ts
@@ -349,6 +349,13 @@ export class GatewayClient {
             method: 'POST',
         });
     }
+
+    async addMeetingParticipant(pollId: string, email: string, name: string): Promise<PollParticipant> {
+        return this.request<PollParticipant>(`/api/v1/meetings/polls/${pollId}/participants`, {
+            method: 'POST',
+            body: { email, name },
+        });
+    }
 }
 
 // Export singleton instance
@@ -502,6 +509,17 @@ export interface PollParticipantCreate {
     name?: string;
     poll_id?: string;
     response_token?: string;
+}
+
+export interface PollParticipant {
+    id: string;
+    email: string;
+    name?: string;
+    status: string;
+    invited_at: string;
+    responded_at?: string;
+    reminder_sent_count: number;
+    response_token: string;
 }
 
 export interface MeetingPollUpdate {


### PR DESCRIPTION
- Replace single "Edit Poll" button with three contextual buttons:
  - "Edit Poll" button inline with meeting title
  - "Add Participant" button inline with "Participant Responses" section
  - "Add Time" button inline with "Time Slots" section
- Add modal dialogs for adding participants and time slots
- Create new API endpoint POST /api/v1/meetings/polls/{poll_id}/participants
- Add addMeetingParticipant method to gateway client
- Remove timezone selector from Add Time modal, use poll's existing timezone
- Improve UI layout with consistent button positioning