### PR TITLE
feat(meetings): add option to reveal participants in poll invitations

### DIFF
--- a/frontend/app/public/meetings/respond/[response_token]/page.tsx
+++ b/frontend/app/public/meetings/respond/[response_token]/page.tsx
@@ -11,13 +11,26 @@ type TimeSlot = {
     is_available: boolean;
 };
 
+type Participant = {
+    id: string;
+    email: string;
+    name?: string;
+    status: string;
+    invited_at: string;
+    responded_at?: string;
+    reminder_sent_count: number;
+    response_token: string;
+};
+
 type Poll = {
     title: string;
     description?: string;
     duration_minutes: number;
     location?: string;
     meeting_type: string;
+    reveal_participants?: boolean;
     time_slots: TimeSlot[];
+    participants?: Participant[];
 };
 
 type PollResponse = {
@@ -229,6 +242,28 @@ export default function PollResponsePage() {
                             <p><strong>Type:</strong> {poll?.meeting_type.replace('_', ' ')}</p>
                         </div>
                     </div>
+
+                    {poll?.reveal_participants && poll?.participants && poll.participants.length > 0 && (
+                        <div className="mb-6 p-4 bg-green-50 rounded-lg">
+                            <div className="flex items-center text-green-800">
+                                <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                                    <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3z" />
+                                </svg>
+                                <span className="font-medium">Other Participants</span>
+                            </div>
+                            <div className="mt-2 text-sm text-green-700">
+                                <ul className="space-y-1">
+                                    {poll.participants.map((participant) => (
+                                        <li key={participant.id} className="flex items-center">
+                                            <span className="font-medium">{participant.name || 'Unknown'}</span>
+                                            <span className="mx-2">•</span>
+                                            <span className="text-green-600">{participant.email}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        </div>
+                    )}
 
                     <form onSubmit={handleSubmit} className="space-y-6">
                         <div>

--- a/frontend/components/meetings/meeting-poll-new.tsx
+++ b/frontend/components/meetings/meeting-poll-new.tsx
@@ -39,6 +39,7 @@ export function MeetingPollNew() {
     // Step 4: Review & Submit
     const [responseDeadline, setResponseDeadline] = useState("");
     const [sendEmails, setSendEmails] = useState(true);
+    const [revealParticipants, setRevealParticipants] = useState(false);
     const [createdPoll, setCreatedPoll] = useState<MeetingPoll | null>(null);
     const [showLinks, setShowLinks] = useState(false);
     // General
@@ -127,6 +128,7 @@ export function MeetingPollNew() {
                 response_deadline: responseDeadline ? new Date(responseDeadline).toISOString() : undefined,
                 time_slots: timeSlots.map((s) => ({ start_time: s.start, end_time: s.end, timezone: timeZone })),
                 participants: participants.map((p) => ({ email: p.email, name: p.name })),
+                reveal_participants: revealParticipants,
             };
             const createdPollData = await gatewayClient.createMeetingPoll(pollData);
             setCreatedPoll(createdPollData);
@@ -365,6 +367,22 @@ export function MeetingPollNew() {
                                             Send email survey to invitees
                                         </label>
                                     </div>
+
+                                    {sendEmails && (
+                                        <div className="flex items-center space-x-2">
+                                            <Checkbox
+                                                id="reveal-participants"
+                                                checked={revealParticipants}
+                                                onCheckedChange={(checked) => setRevealParticipants(checked as boolean)}
+                                            />
+                                            <label
+                                                htmlFor="reveal-participants"
+                                                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                                            >
+                                                Include other participants' names and emails in invitations
+                                            </label>
+                                        </div>
+                                    )}
 
                                     {!sendEmails && (
                                         <Alert>

--- a/frontend/lib/gateway-client.ts
+++ b/frontend/lib/gateway-client.ts
@@ -440,6 +440,7 @@ export interface MeetingPoll {
     response_deadline?: string;
     min_participants?: number;
     max_participants?: number;
+    reveal_participants?: boolean;
     status: string;
     created_at: string;
     updated_at: string;
@@ -487,6 +488,7 @@ export interface MeetingPollCreate {
     response_deadline?: string;
     min_participants?: number;
     max_participants?: number;
+    reveal_participants?: boolean;
     time_slots: TimeSlotCreate[];
     participants: PollParticipantCreate[];
 }

--- a/services/meetings/alembic/versions/516af99cbe18_add_reveal_participants_column.py
+++ b/services/meetings/alembic/versions/516af99cbe18_add_reveal_participants_column.py
@@ -1,0 +1,31 @@
+"""add_reveal_participants_column
+
+Revision ID: 516af99cbe18
+Revises: fix_meeting_type_constraint
+Create Date: 2025-07-27 11:09:10.164046
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "516af99cbe18"
+down_revision = "fix_meeting_type_constraint"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add reveal_participants column to meeting_polls table
+    op.add_column(
+        "meeting_polls",
+        sa.Column(
+            "reveal_participants", sa.Boolean(), nullable=False, server_default="false"
+        ),
+    )
+
+
+def downgrade():
+    # Remove reveal_participants column from meeting_polls table
+    op.drop_column("meeting_polls", "reveal_participants")

--- a/services/meetings/api/invitations.py
+++ b/services/meetings/api/invitations.py
@@ -75,7 +75,22 @@ async def send_invitations(
             response_url = f"{frontend_url}/public/meetings/respond/{getattr(participant, 'response_token')}"
             subject = f"You're invited: {poll.title}"
             description = getattr(poll, "description", "") or ""
+
+            # Build email body
             body = f"You have been invited to respond to a meeting poll: {poll.title}\n\n{description}\n\nRespond here: {response_url}"
+
+            # Add participant list if reveal_participants is enabled
+            if hasattr(poll, "reveal_participants") and getattr(
+                poll, "reveal_participants", False
+            ):
+                body += "\n\nOther participants:\n"
+                for other_participant in participants:
+                    if (
+                        other_participant.id != participant.id
+                    ):  # Don't include the current participant
+                        name = getattr(other_participant, "name", None) or "Unknown"
+                        email = getattr(other_participant, "email", "")
+                        body += f"- {name} ({email})\n"
 
             try:
                 await email_integration.send_invitation_email(

--- a/services/meetings/api/polls.py
+++ b/services/meetings/api/polls.py
@@ -178,6 +178,7 @@ def create_poll(
             response_deadline=poll.response_deadline,
             min_participants=poll.min_participants or 1,
             max_participants=poll.max_participants,
+            reveal_participants=poll.reveal_participants or False,
             poll_token=str(poll_token),
         )
         session.add(db_poll)
@@ -288,6 +289,8 @@ def update_poll(
             db_poll.min_participants = poll.min_participants  # type: ignore[assignment]
         if poll.max_participants is not None:
             db_poll.max_participants = poll.max_participants  # type: ignore[assignment]
+        if poll.reveal_participants is not None:
+            db_poll.reveal_participants = poll.reveal_participants  # type: ignore[assignment]
 
         # TODO: update time slots and participants as needed
         session.commit()

--- a/services/meetings/models/meeting.py
+++ b/services/meetings/models/meeting.py
@@ -61,6 +61,7 @@ class MeetingPoll(Base):
     response_deadline = Column(DateTime(timezone=True))
     min_participants = Column(Integer, default=1)
     max_participants = Column(Integer)
+    reveal_participants = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
     updated_at = Column(
         DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow

--- a/services/meetings/schemas/__init__.py
+++ b/services/meetings/schemas/__init__.py
@@ -74,6 +74,7 @@ class MeetingPollBase(BaseModel):
     response_deadline: Optional[datetime]
     min_participants: Optional[int] = None
     max_participants: Optional[int] = None
+    reveal_participants: Optional[bool] = False
 
     @field_validator("meeting_type", mode="before")
     @classmethod
@@ -130,6 +131,7 @@ class MeetingPollUpdate(BaseModel):
     response_deadline: Optional[datetime] = None
     min_participants: Optional[int] = None
     max_participants: Optional[int] = None
+    reveal_participants: Optional[bool] = None
 
     @field_validator("meeting_type", mode="before")
     @classmethod

--- a/services/meetings/tests/test_poll_authorization.py
+++ b/services/meetings/tests/test_poll_authorization.py
@@ -23,14 +23,20 @@ class TestPollAuthorization(BaseMeetingsTest):
 
         from services.meetings import models
 
-        if not hasattr(models, "_test_engine"):
-            models._test_engine = create_engine(
-                "sqlite:///file::memory:?cache=shared",
-                echo=False,
-                future=True,
-                connect_args={"check_same_thread": False},
-            )
+        # Clear any existing test engine to ensure fresh tables
+        if hasattr(models, "_test_engine"):
+            delattr(models, "_test_engine")
+
+        models._test_engine = create_engine(
+            "sqlite:///file::memory:?cache=shared",
+            echo=False,
+            future=True,
+            connect_args={"check_same_thread": False},
+        )
         models.get_engine = lambda: models._test_engine
+
+        # Drop all tables and recreate them to ensure latest schema
+        Base.metadata.drop_all(models._test_engine)
         Base.metadata.create_all(models._test_engine)
 
     @pytest.fixture
@@ -45,6 +51,7 @@ class TestPollAuthorization(BaseMeetingsTest):
             "response_deadline": (now + timedelta(days=2)).isoformat() + "Z",
             "min_participants": 1,
             "max_participants": 5,
+            "reveal_participants": False,
             "time_slots": [
                 {
                     "start_time": (now + timedelta(days=3)).isoformat() + "Z",

--- a/services/meetings/tests/test_poll_creation.py
+++ b/services/meetings/tests/test_poll_creation.py
@@ -23,14 +23,20 @@ class TestPollCreation(BaseMeetingsTest):
 
         from services.meetings import models
 
-        if not hasattr(models, "_test_engine"):
-            models._test_engine = create_engine(
-                "sqlite:///file::memory:?cache=shared",
-                echo=False,
-                future=True,
-                connect_args={"check_same_thread": False},
-            )
+        # Clear any existing test engine to ensure fresh tables
+        if hasattr(models, "_test_engine"):
+            delattr(models, "_test_engine")
+
+        models._test_engine = create_engine(
+            "sqlite:///file::memory:?cache=shared",
+            echo=False,
+            future=True,
+            connect_args={"check_same_thread": False},
+        )
         models.get_engine = lambda: models._test_engine
+
+        # Drop all tables and recreate them to ensure latest schema
+        Base.metadata.drop_all(models._test_engine)
         Base.metadata.create_all(models._test_engine)
 
     @pytest.fixture
@@ -45,6 +51,7 @@ class TestPollCreation(BaseMeetingsTest):
             "response_deadline": (now + timedelta(days=2)).isoformat() + "Z",
             "min_participants": 1,
             "max_participants": 5,
+            "reveal_participants": False,
             "time_slots": [
                 {
                     "start_time": (now + timedelta(days=3)).isoformat() + "Z",
@@ -158,3 +165,37 @@ class TestPollCreation(BaseMeetingsTest):
         assert "participant_id" in response
         assert "created_at" in response
         assert "updated_at" in response
+
+    def test_create_poll_with_reveal_participants(self, poll_payload):
+        user_id = str(uuid4())
+        # Set reveal_participants to True
+        poll_payload["reveal_participants"] = True
+
+        resp = client.post(
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["user_id"] == user_id
+        assert data["title"] == poll_payload["title"]
+        assert data["reveal_participants"] is True
+        assert data["participants"][0]["email"] == "alice@example.com"
+
+    def test_create_poll_without_reveal_participants(self, poll_payload):
+        user_id = str(uuid4())
+        # Set reveal_participants to False
+        poll_payload["reveal_participants"] = False
+
+        resp = client.post(
+            "/api/v1/meetings/polls/",
+            json=poll_payload,
+            headers={"X-User-Id": user_id, "X-API-Key": "test-frontend-meetings-key"},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["user_id"] == user_id
+        assert data["title"] == poll_payload["title"]
+        assert data["reveal_participants"] is False
+        assert data["participants"][0]["email"] == "alice@example.com"


### PR DESCRIPTION
- Add reveal_participants boolean field to meeting_polls table
- Update API schemas and endpoints to handle the new field
- Add checkbox in frontend poll creation form to enable participant visibility
- Include participant names/emails in invitation emails when enabled
- Display participants list on public response page when reveal_participants is true
- Add comprehensive tests for the new feature
- Fix test database setup to ensure fresh schema creation

This allows poll creators to optionally share participant information
with invitees, improving transparency for meeting coordination.