### PR TITLE
fix(chat): resolve streaming word duplication with SSE event dedup

### DIFF
--- a/frontend/components/chat-interface.tsx
+++ b/frontend/components/chat-interface.tsx
@@ -305,6 +305,8 @@ export default function ChatInterface({ containerRef, onDraftReceived }: ChatInt
                             let eventName: string | null = null
                             let serverMessageId: string | null = null
                             let streamedDraft: DraftData | null = null;
+                            const processedEventIds = new Set<string>(); // Track processed SSE event IDs
+                            let eventId: string | null = null; // Track current SSE event ID
                             while (true) {
                                 const { done, value } = await reader.read()
                                 if (done) break
@@ -314,7 +316,9 @@ export default function ChatInterface({ containerRef, onDraftReceived }: ChatInt
                                 buffer = lines.pop() ?? ""
 
                                 for (const line of lines) {
-                                    if (line.startsWith("event:")) {
+                                    if (line.startsWith("id:")) {
+                                        eventId = line.substring(3).trim();
+                                    } else if (line.startsWith("event:")) {
                                         eventName = line.substring(6).trim()
                                     } else if (line.startsWith("data:")) {
                                         const dataStr = line.substring(5).trim()
@@ -333,12 +337,22 @@ export default function ChatInterface({ containerRef, onDraftReceived }: ChatInt
                                             try {
                                                 const data = JSON.parse(dataStr)
                                                 if (data.delta) {
+                                                    // Check if we've already processed this event ID
+                                                    if (eventId && processedEventIds.has(eventId)) {
+                                                        continue; // Use continue instead of return
+                                                    }
+                                                    if (eventId) {
+                                                        processedEventIds.add(eventId);
+                                                    }
                                                     setMessages((prev) => {
-                                                        const newMessages = [...prev]
-                                                        const lastMessage = newMessages[newMessages.length - 1]
-                                                        if (lastMessage.sender === "ai") {
-                                                            lastMessage.content += data.delta
-                                                        }
+                                                        const newMessages = prev.map((msg, index) => {
+                                                            if (index === prev.length - 1 && msg.sender === "ai") {
+                                                                const oldContent = msg.content
+                                                                const newContent = oldContent + data.delta
+                                                                return { ...msg, content: newContent }
+                                                            }
+                                                            return msg
+                                                        })
                                                         return newMessages
                                                     })
                                                 }
@@ -348,6 +362,7 @@ export default function ChatInterface({ containerRef, onDraftReceived }: ChatInt
                                         }
                                     } else if (line.trim() === "") {
                                         eventName = null // Reset on blank line
+                                        // Don't reset eventId here - keep it for the next event
                                     }
                                 }
                             }

--- a/services/chat/api.py
+++ b/services/chat/api.py
@@ -289,7 +289,9 @@ async def chat_stream_endpoint(
                         "delta": delta_value,
                     }
                     full_response += delta_value
-                    yield f"event: chunk\ndata: {json.dumps(event_data)}\n\n"
+                    # Add unique ID for deduplication
+                    event_id = f"delta_{len(full_response)}_{hash(delta_value)}"
+                    yield f"id: {event_id}\nevent: chunk\ndata: {json.dumps(event_data)}\n\n"
                 else:
                     # Log internal events for debugging but don't stream them to client
                     logger.debug(


### PR DESCRIPTION
- Implement SSE event ID generation for client-side deduplication
- Fix frontend state mutation causing React re-render loops
- Use continue instead of return in deduplication logic to prevent loop exit
- Preserve event IDs across SSE parsing to maintain proper tracking

The streaming duplication was caused by:
1. Gateway proxy sending each SSE event twice
2. Frontend state mutation triggering multiple React re-renders
3. Missing deduplication logic for duplicate SSE events