### PR TITLE
feat: add chat panel toggle with persistent state management

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,5 @@
 import AuthSessionProvider from '@/components/auth/session-provider';
+import { ChatPanelProvider } from '@/contexts/chat-panel-context';
 import { IntegrationsProvider } from '@/contexts/integrations-context';
 import { UserPreferencesProvider } from '@/contexts/settings-context';
 import type { Metadata } from 'next';
@@ -20,7 +21,9 @@ export default function RootLayout({
                 <AuthSessionProvider>
                     <IntegrationsProvider>
                         <UserPreferencesProvider>
-                            {children}
+                            <ChatPanelProvider>
+                                {children}
+                            </ChatPanelProvider>
                         </UserPreferencesProvider>
                     </IntegrationsProvider>
                 </AuthSessionProvider>

--- a/frontend/components/layout/app-layout.tsx
+++ b/frontend/components/layout/app-layout.tsx
@@ -15,7 +15,7 @@ interface AppLayoutProps {
 export function AppLayout({ sidebar, main, draft, draftPane, hasActiveDraft = false }: AppLayoutProps) {
     const chatPaneRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>;
     const containerRef = useRef<HTMLDivElement>(null);
-    const { isOpen, width, effectiveWidth, setWidth } = useChatPanelState();
+    const { isOpen, effectiveWidth, setWidth } = useChatPanelState();
     const [containerWidth, setContainerWidth] = useState<number>(0);
     const [localChatWidth, setLocalChatWidth] = useState<number>(0);
 
@@ -100,13 +100,13 @@ export function AppLayout({ sidebar, main, draft, draftPane, hasActiveDraft = fa
                             <ResizablePanel id="main-panel" order={1} minSize={30} defaultSize={mainSize} className="h-full">
                                 {draftPane && hasActiveDraft ? (
                                     <ResizablePanelGroup direction="vertical" className="h-full">
-                                        <ResizablePanel minSize={10} size={50} className="h-full">
+                                        <ResizablePanel minSize={10} defaultSize={50} className="h-full">
                                             <div className="h-full overflow-auto">
                                                 {main || <div className="flex-1 flex items-center justify-center text-muted-foreground">Main Pane</div>}
                                             </div>
                                         </ResizablePanel>
                                         <ResizableHandle withHandle />
-                                        <ResizablePanel minSize={10} size={50} className="h-full min-h-0 border-t bg-card">
+                                        <ResizablePanel minSize={10} defaultSize={50} className="h-full min-h-0 border-t bg-card">
                                             <div className="h-full overflow-auto">
                                                 {draftPane}
                                             </div>
@@ -149,13 +149,13 @@ export function AppLayout({ sidebar, main, draft, draftPane, hasActiveDraft = fa
                         <div ref={containerRef} className="flex-1 min-w-0 h-full flex flex-col">
                             {draftPane && hasActiveDraft ? (
                                 <ResizablePanelGroup direction="vertical" className="h-full">
-                                    <ResizablePanel minSize={10} size={50} className="h-full">
+                                    <ResizablePanel minSize={10} defaultSize={50} className="h-full">
                                         <div className="h-full overflow-auto">
                                             {main || <div className="flex-1 flex items-center justify-center text-muted-foreground">Main Pane</div>}
                                         </div>
                                     </ResizablePanel>
                                     <ResizableHandle withHandle />
-                                    <ResizablePanel minSize={10} size={50} className="h-full min-h-0 border-t bg-card">
+                                    <ResizablePanel minSize={10} defaultSize={50} className="h-full min-h-0 border-t bg-card">
                                         <div className="h-full overflow-auto">
                                             {draftPane}
                                         </div>

--- a/frontend/components/layout/app-layout.tsx
+++ b/frontend/components/layout/app-layout.tsx
@@ -76,21 +76,20 @@ export function AppLayout({ sidebar, main, draft, draftPane, hasActiveDraft = fa
                 <div ref={containerRef} className="flex-1 min-w-0 h-full flex flex-col">
                     {draft ? (
                         <ResizablePanelGroup
-                            key={`chat-${isOpen ? 'open' : 'closed'}-${chatSize}`}
                             className="flex-1 flex min-w-0"
                             direction="horizontal"
                             onLayout={handlePanelResize}
                         >
-                            <ResizablePanel minSize={30} defaultSize={mainSize} className="h-full">
+                            <ResizablePanel minSize={30} size={mainSize} className="h-full">
                                 {draftPane && hasActiveDraft ? (
                                     <ResizablePanelGroup direction="vertical" className="h-full">
-                                        <ResizablePanel minSize={10} defaultSize={50} className="h-full">
+                                        <ResizablePanel minSize={10} size={50} className="h-full">
                                             <div className="h-full overflow-auto">
                                                 {main || <div className="flex-1 flex items-center justify-center text-muted-foreground">Main Pane</div>}
                                             </div>
                                         </ResizablePanel>
                                         <ResizableHandle withHandle />
-                                        <ResizablePanel minSize={10} defaultSize={50} className="h-full min-h-0 border-t bg-card">
+                                        <ResizablePanel minSize={10} size={50} className="h-full min-h-0 border-t bg-card">
                                             <div className="h-full overflow-auto">
                                                 {draftPane}
                                             </div>
@@ -114,7 +113,7 @@ export function AppLayout({ sidebar, main, draft, draftPane, hasActiveDraft = fa
                                     <ResizableHandle withHandle />
                                     <ResizablePanel
                                         minSize={20}
-                                        defaultSize={chatSize}
+                                        size={chatSize}
                                         collapsible
                                         className="h-full border-l bg-card"
                                     >
@@ -131,13 +130,13 @@ export function AppLayout({ sidebar, main, draft, draftPane, hasActiveDraft = fa
                         <div ref={containerRef} className="flex-1 min-w-0 h-full flex flex-col">
                             {draftPane && hasActiveDraft ? (
                                 <ResizablePanelGroup direction="vertical" className="h-full">
-                                    <ResizablePanel minSize={10} defaultSize={50} className="h-full">
+                                    <ResizablePanel minSize={10} size={50} className="h-full">
                                         <div className="h-full overflow-auto">
                                             {main || <div className="flex-1 flex items-center justify-center text-muted-foreground">Main Pane</div>}
                                         </div>
                                     </ResizablePanel>
                                     <ResizableHandle withHandle />
-                                    <ResizablePanel minSize={10} defaultSize={50} className="h-full min-h-0 border-t bg-card">
+                                    <ResizablePanel minSize={10} size={50} className="h-full min-h-0 border-t bg-card">
                                         <div className="h-full overflow-auto">
                                             {draftPane}
                                         </div>

--- a/frontend/components/layout/app-layout.tsx
+++ b/frontend/components/layout/app-layout.tsx
@@ -1,6 +1,7 @@
 import Navbar from "@/components/navbar";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import { SidebarProvider } from "@/components/ui/sidebar";
+import { useChatPanelState } from "@/contexts/chat-panel-context";
 import React, { ReactElement, ReactNode, RefObject, useRef } from "react";
 
 interface AppLayoutProps {
@@ -13,6 +14,34 @@ interface AppLayoutProps {
 
 export function AppLayout({ sidebar, main, draft, draftPane, hasActiveDraft = false }: AppLayoutProps) {
     const chatPaneRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>;
+    const { isOpen, width, setWidth } = useChatPanelState();
+
+    // Calculate panel sizes based on chat state
+    const getPanelSizes = () => {
+        if (!isOpen) {
+            return { mainSize: 100, chatSize: 0 };
+        }
+
+        // Calculate chat panel size as percentage of total width
+        // Assuming a reasonable total width for calculation
+        const totalWidth = 1200; // Approximate total width
+        const chatSizePercent = Math.round((width / totalWidth) * 100);
+        const mainSizePercent = 100 - chatSizePercent;
+
+        return { mainSize: mainSizePercent, chatSize: chatSizePercent };
+    };
+
+    const { mainSize, chatSize } = getPanelSizes();
+
+    const handlePanelResize = (sizes: number[]) => {
+        if (sizes.length >= 2) {
+            // Calculate actual width from percentage
+            const totalWidth = 1200; // Approximate total width
+            const newChatWidth = Math.round((sizes[1] / 100) * totalWidth);
+            setWidth(newChatWidth);
+        }
+    };
+
     return (
         <div className="flex flex-col h-screen w-full bg-background">
             <Navbar />
@@ -24,8 +53,13 @@ export function AppLayout({ sidebar, main, draft, draftPane, hasActiveDraft = fa
                 </div>
                 <div className="flex-1 min-w-0 h-full flex flex-col">
                     {draft ? (
-                        <ResizablePanelGroup className="flex-1 flex min-w-0" direction="horizontal">
-                            <ResizablePanel minSize={30} defaultSize={70} className="h-full">
+                        <ResizablePanelGroup
+                            key={`chat-${isOpen ? 'open' : 'closed'}-${chatSize}`}
+                            className="flex-1 flex min-w-0"
+                            direction="horizontal"
+                            onLayout={handlePanelResize}
+                        >
+                            <ResizablePanel minSize={30} defaultSize={mainSize} className="h-full">
                                 {draftPane && hasActiveDraft ? (
                                     <ResizablePanelGroup direction="vertical" className="h-full">
                                         <ResizablePanel minSize={10} defaultSize={50} className="h-full">
@@ -53,14 +87,23 @@ export function AppLayout({ sidebar, main, draft, draftPane, hasActiveDraft = fa
                                     </div>
                                 )}
                             </ResizablePanel>
-                            <ResizableHandle withHandle />
-                            <ResizablePanel minSize={20} defaultSize={30} collapsible className="h-full border-l bg-card">
-                                <div className="h-full overflow-auto" ref={chatPaneRef}>
-                                    {draft
-                                        ? React.cloneElement(draft, { containerRef: chatPaneRef })
-                                        : <div className="flex-1 flex items-center justify-center text-muted-foreground">Chat Pane</div>}
-                                </div>
-                            </ResizablePanel>
+                            {isOpen && (
+                                <>
+                                    <ResizableHandle withHandle />
+                                    <ResizablePanel
+                                        minSize={20}
+                                        defaultSize={chatSize}
+                                        collapsible
+                                        className="h-full border-l bg-card"
+                                    >
+                                        <div className="h-full overflow-auto" ref={chatPaneRef}>
+                                            {draft
+                                                ? React.cloneElement(draft, { containerRef: chatPaneRef })
+                                                : <div className="flex-1 flex items-center justify-center text-muted-foreground">Chat Pane</div>}
+                                        </div>
+                                    </ResizablePanel>
+                                </>
+                            )}
                         </ResizablePanelGroup>
                     ) : (
                         <div className="flex-1 min-w-0 h-full flex flex-col">

--- a/frontend/components/navbar.tsx
+++ b/frontend/components/navbar.tsx
@@ -1,9 +1,12 @@
 import UserMenu from "@/components/auth/user-menu";
 import { Button } from "@/components/ui/button";
-import { Sailboat, Settings } from "lucide-react";
+import { useChatPanelState } from "@/contexts/chat-panel-context";
+import { MessageSquare, MessageSquareOff, Sailboat, Settings } from "lucide-react";
 import Link from "next/link";
 
 export default function Navbar() {
+    const { isOpen, toggle } = useChatPanelState();
+
     return (
         <header className="bg-white border-b w-full">
             <div className="flex flex-row items-center justify-between w-full px-4 py-3">
@@ -14,6 +17,19 @@ export default function Navbar() {
                     </Link>
                 </div>
                 <div className="flex items-center gap-4 min-w-0">
+                    <Button
+                        variant={isOpen ? "default" : "outline"}
+                        size="sm"
+                        onClick={toggle}
+                        className={isOpen ? "bg-teal-600 hover:bg-teal-700" : ""}
+                        title={isOpen ? "Close chat" : "Open chat"}
+                    >
+                        {isOpen ? (
+                            <MessageSquare className="h-4 w-4" />
+                        ) : (
+                            <MessageSquareOff className="h-4 w-4" />
+                        )}
+                    </Button>
                     <Button variant="outline" size="sm" asChild>
                         <Link href="/settings">
                             <Settings className="h-4 w-4" />

--- a/frontend/contexts/chat-panel-context.tsx
+++ b/frontend/contexts/chat-panel-context.tsx
@@ -2,6 +2,22 @@
 
 import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 
+/**
+ * Chat Panel State Management Strategy
+ * 
+ * Strategy:
+ * 1. Provider returns effectiveWidth: Returns the actual width when open, 0 when closed
+ * 2. Local state tracking: Component maintains localChatWidth for immediate sizing
+ * 3. Sync logic: When provider's effectiveWidth differs from local width, sync them
+ * 4. No re-rendering: Tool content stays mounted because we removed the key prop
+ * 
+ * How it works:
+ * 1. User resizes: Updates both local width and provider width
+ * 2. User closes chat: Provider effectiveWidth becomes 0, local width resets to 0
+ * 3. User reopens chat: Provider effectiveWidth becomes the saved width, local width syncs to it
+ * 4. Tool content: Never re-renders because no key prop forces remounting
+ */
+
 interface ChatPanelState {
     isOpen: boolean;
     width: number;

--- a/frontend/contexts/chat-panel-context.tsx
+++ b/frontend/contexts/chat-panel-context.tsx
@@ -10,6 +10,7 @@ interface ChatPanelState {
 interface ChatPanelContextType {
     isOpen: boolean;
     width: number;
+    effectiveWidth: number; // Returns width if open, 0 if closed
     setIsOpen: (isOpen: boolean) => void;
     setWidth: (width: number) => void;
     toggle: () => void;
@@ -74,6 +75,7 @@ export function ChatPanelProvider({ children }: { children: ReactNode }) {
     const value: ChatPanelContextType = {
         isOpen: state.isOpen,
         width: state.width,
+        effectiveWidth: state.isOpen ? state.width : 0,
         setIsOpen,
         setWidth,
         toggle,

--- a/frontend/contexts/chat-panel-context.tsx
+++ b/frontend/contexts/chat-panel-context.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
+
+interface ChatPanelState {
+    isOpen: boolean;
+    width: number;
+}
+
+interface ChatPanelContextType {
+    isOpen: boolean;
+    width: number;
+    setIsOpen: (isOpen: boolean) => void;
+    setWidth: (width: number) => void;
+    toggle: () => void;
+    minWidth: number;
+    maxWidth: number;
+}
+
+const DEFAULT_CHAT_WIDTH = 400;
+const MIN_CHAT_WIDTH = 200;
+const MAX_CHAT_WIDTH = 800;
+
+const ChatPanelContext = createContext<ChatPanelContextType | undefined>(undefined);
+
+export function ChatPanelProvider({ children }: { children: ReactNode }) {
+    const [state, setState] = useState<ChatPanelState>(() => {
+        // Initialize from localStorage if available
+        if (typeof window !== 'undefined') {
+            try {
+                const saved = localStorage.getItem('briefly-chat-panel-state');
+                if (saved) {
+                    const parsed = JSON.parse(saved);
+                    return {
+                        isOpen: parsed.isOpen ?? true,
+                        width: Math.max(MIN_CHAT_WIDTH, Math.min(MAX_CHAT_WIDTH, parsed.width ?? DEFAULT_CHAT_WIDTH)),
+                    };
+                }
+            } catch (error) {
+                console.warn('Failed to load chat panel state from localStorage:', error);
+            }
+        }
+        return {
+            isOpen: true,
+            width: DEFAULT_CHAT_WIDTH,
+        };
+    });
+
+    const setIsOpen = useCallback((isOpen: boolean) => {
+        setState(prev => ({ ...prev, isOpen }));
+    }, []);
+
+    const setWidth = useCallback((width: number) => {
+        const clampedWidth = Math.max(MIN_CHAT_WIDTH, Math.min(MAX_CHAT_WIDTH, width));
+        setState(prev => ({ ...prev, width: clampedWidth }));
+    }, []);
+
+    const toggle = useCallback(() => {
+        setState(prev => ({ ...prev, isOpen: !prev.isOpen }));
+    }, []);
+
+    // Persist state to localStorage
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            try {
+                localStorage.setItem('briefly-chat-panel-state', JSON.stringify(state));
+            } catch (error) {
+                console.warn('Failed to save chat panel state to localStorage:', error);
+            }
+        }
+    }, [state]);
+
+    const value: ChatPanelContextType = {
+        isOpen: state.isOpen,
+        width: state.width,
+        setIsOpen,
+        setWidth,
+        toggle,
+        minWidth: MIN_CHAT_WIDTH,
+        maxWidth: MAX_CHAT_WIDTH,
+    };
+
+    return (
+        <ChatPanelContext.Provider value={value}>
+            {children}
+        </ChatPanelContext.Provider>
+    );
+}
+
+export function useChatPanelState(): ChatPanelContextType {
+    const context = useContext(ChatPanelContext);
+    if (context === undefined) {
+        throw new Error('useChatPanelState must be used within a ChatPanelProvider');
+    }
+    return context;
+} 

--- a/frontend/contexts/chat-panel-context.tsx
+++ b/frontend/contexts/chat-panel-context.tsx
@@ -51,7 +51,8 @@ export function ChatPanelProvider({ children }: { children: ReactNode }) {
     }, []);
 
     const setWidth = useCallback((width: number) => {
-        const clampedWidth = Math.max(MIN_CHAT_WIDTH, Math.min(MAX_CHAT_WIDTH, width));
+        // Ensure width is within valid bounds and is a positive number
+        const clampedWidth = Math.max(MIN_CHAT_WIDTH, Math.min(MAX_CHAT_WIDTH, Math.max(0, width)));
         setState(prev => ({ ...prev, width: clampedWidth }));
     }, []);
 


### PR DESCRIPTION
feat: implement persistent chat panel sizing with local state sync

- Add effectiveWidth to ChatPanelProvider that returns width when open, 0 when closed
- Implement local state tracking in AppLayout to maintain immediate sizing
- Add sync logic to reconcile provider and local width differences
- Remove key prop to prevent tool content reloading during chat panel operations
- Preserve user state and prevent jarring re-renders while maintaining size persistence

Strategy:
- Provider returns effectiveWidth: Returns actual width when open, 0 when closed
- Local state tracking: Component maintains localChatWidth for immediate sizing  
- Sync logic: When provider's effectiveWidth differs from local width, sync them
- No re-rendering: Tool content stays mounted because we removed the key prop
