### PR TITLE
fix(office): use request trace ID instead of generating new UUIDs

### DIFF
--- a/services/chat/tests/test_chat_service_e2e.py
+++ b/services/chat/tests/test_chat_service_e2e.py
@@ -9,7 +9,6 @@ import sys
 from unittest.mock import patch
 
 import pytest
-import respx
 from fastapi.testclient import TestClient
 
 # Set up test settings before any imports
@@ -193,7 +192,6 @@ class TestChatServiceE2E(BaseChatTest):
         assert thread_id1 in thread_ids
         assert thread_id2 in thread_ids
 
-    @respx.mock
     def test_request_id_propagation(self):
         """
         Test that X-Request-Id is properly propagated to downstream services.

--- a/services/chat/tests/test_chat_service_e2e.py
+++ b/services/chat/tests/test_chat_service_e2e.py
@@ -15,6 +15,7 @@ from httpx import Response
 
 # Set up test settings before any imports
 import services.chat.settings as chat_settings
+from services.chat.tests.test_base import BaseChatTest
 
 # Create test settings instance
 test_settings = chat_settings.Settings(
@@ -47,188 +48,186 @@ def test_env():
         yield env_vars
 
 
-@pytest.fixture
-def app(test_env):
-    """Fixture to provide the FastAPI app with test environment."""
-    # Force reload the auth module to pick up the new settings
-    for module in list(sys.modules):
-        if module.startswith("services.chat"):
-            del sys.modules[module]
+class TestChatServiceE2E(BaseChatTest):
+    @classmethod
+    def setup_class(cls):
+        # Set up environment variables
+        env_vars = {
+            "DB_URL_CHAT": "sqlite+aiosqlite:///file::memory:?cache=shared",
+            # Don't set OPENAI_API_KEY so it falls back to FakeLLM
+            "LLM_MODEL": "fake-model",
+            "LLM_PROVIDER": "fake",
+        }
+        patcher = patch.dict("os.environ", env_vars)
+        patcher.start()
+        cls._env_patcher = patcher
+        # Force reload the auth module to pick up the new settings
+        for module in list(sys.modules):
+            if module.startswith("services.chat"):
+                del sys.modules[module]
+        import services.chat.settings as chat_settings
+        from services.chat import history_manager
+        from services.chat.main import app as fresh_app
 
-    # Import after module cleanup to ensure fresh imports
-    # Re-set the test settings after module reload
-    import services.chat.settings as chat_settings
-    from services.chat import history_manager
-    from services.chat.main import app as fresh_app
+        test_settings = chat_settings.Settings(
+            db_url_chat="sqlite+aiosqlite:///file::memory:?cache=shared",
+            api_frontend_chat_key="test-frontend-chat-key",
+            api_chat_user_key="test-chat-user-key",
+            api_chat_office_key="test-chat-office-key",
+            user_service_url="http://localhost:8001",
+            office_service_url="http://localhost:8003",
+        )
+        chat_settings._settings = test_settings
+        cls._history_manager = history_manager
+        cls.app = fresh_app
+        # Initialize test database synchronously
+        import asyncio
 
-    test_settings = chat_settings.Settings(
-        db_url_chat="sqlite+aiosqlite:///file::memory:?cache=shared",
-        api_frontend_chat_key="test-frontend-chat-key",
-        api_chat_user_key="test-chat-user-key",
-        api_chat_office_key="test-chat-office-key",
-        user_service_url="http://localhost:8001",
-        office_service_url="http://localhost:8003",
-    )
-    chat_settings._settings = test_settings
+        asyncio.run(history_manager.init_db())
 
-    # Update the global _history_manager reference
-    global _history_manager
-    _history_manager = history_manager
+    @classmethod
+    def teardown_class(cls):
+        if hasattr(cls, "_env_patcher"):
+            cls._env_patcher.stop()
 
-    return fresh_app
+    def test_end_to_end_chat_flow(self):
+        client = TestClient(self.app)
+        user_id = "testuser"
+        headers_with_user = {**TEST_HEADERS, "X-User-Id": user_id}
 
+        # List threads (record initial count)
+        resp = client.get("/v1/chat/threads", headers=headers_with_user)
+        assert resp.status_code == 200
 
-@pytest.fixture(autouse=True)
-def setup_test_environment(app):
-    """Set up the test environment."""
-    # Initialize test database synchronously
-    import asyncio
+        # Start a chat (should create a new thread and return response)
+        msg = "Hello, world!"
+        resp = client.post(
+            "/v1/chat/completions", json={"message": msg}, headers=headers_with_user
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "thread_id" in data
+        assert "messages" in data
+        assert len(data["messages"]) > 0
+        # Verify we got a response (content varies based on LLM availability)
+        assert data["messages"][-1]["content"] is not None
+        assert len(data["messages"][-1]["content"]) > 0
 
-    from services.chat import history_manager
+        thread_id = data["thread_id"]
 
-    asyncio.run(history_manager.init_db())
+        # Send another message in the same thread
+        msg2 = "How are you?"
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"thread_id": thread_id, "message": msg2},
+            headers=headers_with_user,
+        )
+        assert resp.status_code == 200
+        data2 = resp.json()
+        assert data2["thread_id"] == thread_id
+        # Verify we got a response (content varies based on LLM availability)
+        assert data2["messages"][-1]["content"] is not None
+        assert len(data2["messages"][-1]["content"]) > 0
 
+        # List threads (should contain the thread we just used)
+        resp = client.get("/v1/chat/threads", headers=headers_with_user)
+        assert resp.status_code == 200
+        threads_resp = resp.json()
+        threads = threads_resp["threads"]
+        assert any(t["thread_id"] == thread_id for t in threads)
 
-def test_end_to_end_chat_flow(app):
-    client = TestClient(app)
-    user_id = "testuser"
-    headers_with_user = {**TEST_HEADERS, "X-User-Id": user_id}
+        # Get thread history
+        resp = client.get(f"/v1/chat/threads/{thread_id}/history", headers=TEST_HEADERS)
+        assert resp.status_code == 200
+        history = resp.json()
+        assert history["thread_id"] == thread_id
+        assert len(history["messages"]) >= 2
 
-    # List threads (record initial count)
-    resp = client.get("/v1/chat/threads", headers=headers_with_user)
-    assert resp.status_code == 200
+        # Feedback endpoint
+        last_msg = history["messages"][-1]
+        resp = client.post(
+            "/v1/chat/feedback",
+            json={
+                "thread_id": thread_id,
+                "message_id": last_msg["message_id"],
+                "feedback": "up",
+            },
+            headers=headers_with_user,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "success"
 
-    # Start a chat (should create a new thread and return response)
-    msg = "Hello, world!"
-    resp = client.post(
-        "/v1/chat/completions", json={"message": msg}, headers=headers_with_user
-    )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert "thread_id" in data
-    assert "messages" in data
-    assert len(data["messages"]) > 0
-    # Verify we got a response (content varies based on LLM availability)
-    assert data["messages"][-1]["content"] is not None
-    assert len(data["messages"][-1]["content"]) > 0
+    def test_multiple_blank_thread_creates_distinct_threads(self):
+        client = TestClient(self.app)
+        user_id = "testuser_multi"
+        headers_with_user = {**TEST_HEADERS, "X-User-Id": user_id}
 
-    thread_id = data["thread_id"]
+        # Send first message with blank thread_id
+        resp1 = client.post(
+            "/v1/chat/completions",
+            json={"message": "First message"},
+            headers=headers_with_user,
+        )
+        assert resp1.status_code == 200
+        data1 = resp1.json()
+        thread_id1 = data1["thread_id"]
 
-    # Send another message in the same thread
-    msg2 = "How are you?"
-    resp = client.post(
-        "/v1/chat/completions",
-        json={"thread_id": thread_id, "message": msg2},
-        headers=headers_with_user,
-    )
-    assert resp.status_code == 200
-    data2 = resp.json()
-    assert data2["thread_id"] == thread_id
-    # Verify we got a response (content varies based on LLM availability)
-    assert data2["messages"][-1]["content"] is not None
-    assert len(data2["messages"][-1]["content"]) > 0
+        # Send second message with blank thread_id
+        resp2 = client.post(
+            "/v1/chat/completions",
+            json={"message": "Second message"},
+            headers=headers_with_user,
+        )
+        assert resp2.status_code == 200
+        data2 = resp2.json()
+        thread_id2 = data2["thread_id"]
 
-    # List threads (should contain the thread we just used)
-    resp = client.get("/v1/chat/threads", headers=headers_with_user)
-    assert resp.status_code == 200
-    threads_resp = resp.json()
-    threads = threads_resp["threads"]
-    assert any(t["thread_id"] == thread_id for t in threads)
+        # The thread IDs should be different
+        assert thread_id1 != thread_id2
 
-    # Get thread history
-    resp = client.get(f"/v1/chat/threads/{thread_id}/history", headers=TEST_HEADERS)
-    assert resp.status_code == 200
-    history = resp.json()
-    assert history["thread_id"] == thread_id
-    assert len(history["messages"]) >= 2
+        # List threads and verify both thread IDs are present
+        resp = client.get("/v1/chat/threads", headers=headers_with_user)
+        assert resp.status_code == 200
+        threads_resp = resp.json()
+        threads = threads_resp["threads"]
+        thread_ids = {t["thread_id"] for t in threads}
+        assert thread_id1 in thread_ids
+        assert thread_id2 in thread_ids
 
-    # Feedback endpoint
-    last_msg = history["messages"][-1]
-    resp = client.post(
-        "/v1/chat/feedback",
-        json={
-            "thread_id": thread_id,
-            "message_id": last_msg["message_id"],
-            "feedback": "up",
-        },
-        headers=headers_with_user,
-    )
-    assert resp.status_code == 200
-    assert resp.json()["status"] == "success"
+    @respx.mock
+    def test_request_id_propagation(self):
+        """
+        Test that X-Request-Id is properly propagated to downstream services.
+        """
+        # Arrange
+        client = TestClient(self.app)
+        test_request_id = "test-req-id-123"
+        user_id = "test-user-for-req-id"
 
+        # Mock the downstream user service
+        # The URL must match what's configured in the test_env fixture
+        user_service_url = "http://localhost:8001"
 
-def test_multiple_blank_thread_creates_distinct_threads(app):
-    client = TestClient(app)
-    user_id = "testuser_multi"
-    headers_with_user = {**TEST_HEADERS, "X-User-Id": user_id}
+        # Mock the get_user_preferences call
+        preferences_route = respx.get(
+            f"{user_service_url}/v1/internal/users/{user_id}/preferences"
+        ).mock(return_value=Response(200, json={"timezone": "UTC"}))
 
-    # Send first message with blank thread_id
-    resp1 = client.post(
-        "/v1/chat/completions",
-        json={"message": "First message"},
-        headers=headers_with_user,
-    )
-    assert resp1.status_code == 200
-    data1 = resp1.json()
-    thread_id1 = data1["thread_id"]
+        # Act
+        headers = {
+            "X-API-Key": TEST_API_KEY,
+            "X-Request-Id": test_request_id,
+            "X-User-Id": user_id,
+        }
+        # The /v1/chat/completions endpoint triggers a call to get_user_preferences
+        response = client.post(
+            "/v1/chat/completions", headers=headers, json={"message": "Hello"}
+        )
 
-    # Send second message with blank thread_id
-    resp2 = client.post(
-        "/v1/chat/completions",
-        json={"message": "Second message"},
-        headers=headers_with_user,
-    )
-    assert resp2.status_code == 200
-    data2 = resp2.json()
-    thread_id2 = data2["thread_id"]
+        # Assert
+        assert response.status_code == 200
+        assert preferences_route.called, "The downstream service was not called."
 
-    # The thread IDs should be different
-    assert thread_id1 != thread_id2
-
-    # List threads and verify both thread IDs are present
-    resp = client.get("/v1/chat/threads", headers=headers_with_user)
-    assert resp.status_code == 200
-    threads_resp = resp.json()
-    threads = threads_resp["threads"]
-    thread_ids = {t["thread_id"] for t in threads}
-    assert thread_id1 in thread_ids
-    assert thread_id2 in thread_ids
-
-
-@respx.mock
-def test_request_id_propagation(app):
-    """
-    Test that X-Request-Id is properly propagated to downstream services.
-    """
-    # Arrange
-    client = TestClient(app)
-    test_request_id = "test-req-id-123"
-    user_id = "test-user-for-req-id"
-
-    # Mock the downstream user service
-    # The URL must match what's configured in the test_env fixture
-    user_service_url = "http://localhost:8001"
-
-    # Mock the get_user_preferences call
-    preferences_route = respx.get(
-        f"{user_service_url}/v1/internal/users/{user_id}/preferences"
-    ).mock(return_value=Response(200, json={"timezone": "UTC"}))
-
-    # Act
-    headers = {
-        "X-API-Key": TEST_API_KEY,
-        "X-Request-Id": test_request_id,
-        "X-User-Id": user_id,
-    }
-    # The /v1/chat/completions endpoint triggers a call to get_user_preferences
-    response = client.post(
-        "/v1/chat/completions", headers=headers, json={"message": "Hello"}
-    )
-
-    # Assert
-    assert response.status_code == 200
-    assert preferences_route.called, "The downstream service was not called."
-
-    # Check the headers of the request made to the downstream service
-    last_request = preferences_route.calls.last.request
-    assert last_request.headers.get("x-request-id") == test_request_id
+        # Check the headers of the request made to the downstream service
+        last_request = preferences_route.calls.last.request
+        assert last_request.headers.get("x-request-id") == test_request_id

--- a/services/meetings/models/meeting.py
+++ b/services/meetings/models/meeting.py
@@ -1,6 +1,6 @@
 import enum
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import (
     Boolean,
@@ -64,9 +64,13 @@ class MeetingPoll(Base):
     min_participants = Column(Integer, default=1)
     max_participants = Column(Integer)
     reveal_participants: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     updated_at = Column(
-        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
     )
     scheduled_slot_id = Column(UUID(as_uuid=True), ForeignKey("time_slots.id"))
     poll_token = Column(String(64), unique=True, nullable=False)
@@ -96,7 +100,9 @@ class TimeSlot(Base):
     end_time = Column(DateTime(timezone=True), nullable=False)
     timezone = Column(String(50), nullable=False)
     is_available = Column(Boolean, default=True)
-    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
 
     poll = relationship(
         "MeetingPoll", back_populates="time_slots", foreign_keys="[TimeSlot.poll_id]"
@@ -121,7 +127,9 @@ class PollParticipant(Base):
     status: Mapped[ParticipantStatus] = mapped_column(
         Enum(ParticipantStatus), default=ParticipantStatus.pending
     )
-    invited_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    invited_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     responded_at = Column(DateTime(timezone=True))
     reminder_sent_count = Column(Integer, default=0)
     response_token = Column(String(64), unique=True, nullable=False)
@@ -156,9 +164,13 @@ class PollResponse(Base):
     )
     response: Mapped[ResponseType] = mapped_column(Enum(ResponseType), nullable=False)
     comment = Column(Text)
-    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
     updated_at = Column(
-        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
     )
 
     participant = relationship("PollParticipant", back_populates="responses")
@@ -178,4 +190,6 @@ class ChatMeeting(Base):
     chat_message = Column(Text, nullable=False)
     extracted_intent = Column(Text)  # Store as JSON string
     poll_id = Column(UUID(as_uuid=True), ForeignKey("meeting_polls.id"))
-    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )

--- a/services/meetings/models/meeting.py
+++ b/services/meetings/models/meeting.py
@@ -1,6 +1,6 @@
 import enum
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 
 from sqlalchemy import (
     Boolean,
@@ -17,11 +17,6 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from services.meetings.models.base import Base
-
-
-def utc_now() -> datetime:
-    """Return current UTC datetime with timezone info."""
-    return datetime.now(timezone.utc)
 
 
 class MeetingType(str, enum.Enum):
@@ -69,8 +64,10 @@ class MeetingPoll(Base):
     min_participants = Column(Integer, default=1)
     max_participants = Column(Integer)
     reveal_participants: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at = Column(DateTime(timezone=True), default=utc_now)
-    updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at = Column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )
     scheduled_slot_id = Column(UUID(as_uuid=True), ForeignKey("time_slots.id"))
     poll_token = Column(String(64), unique=True, nullable=False)
 
@@ -99,7 +96,7 @@ class TimeSlot(Base):
     end_time = Column(DateTime(timezone=True), nullable=False)
     timezone = Column(String(50), nullable=False)
     is_available = Column(Boolean, default=True)
-    created_at = Column(DateTime(timezone=True), default=utc_now)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
 
     poll = relationship(
         "MeetingPoll", back_populates="time_slots", foreign_keys="[TimeSlot.poll_id]"
@@ -124,7 +121,7 @@ class PollParticipant(Base):
     status: Mapped[ParticipantStatus] = mapped_column(
         Enum(ParticipantStatus), default=ParticipantStatus.pending
     )
-    invited_at = Column(DateTime(timezone=True), default=utc_now)
+    invited_at = Column(DateTime(timezone=True), default=datetime.utcnow)
     responded_at = Column(DateTime(timezone=True))
     reminder_sent_count = Column(Integer, default=0)
     response_token = Column(String(64), unique=True, nullable=False)
@@ -159,8 +156,10 @@ class PollResponse(Base):
     )
     response: Mapped[ResponseType] = mapped_column(Enum(ResponseType), nullable=False)
     comment = Column(Text)
-    created_at = Column(DateTime(timezone=True), default=utc_now)
-    updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at = Column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )
 
     participant = relationship("PollParticipant", back_populates="responses")
     time_slot = relationship("TimeSlot", back_populates="responses")
@@ -179,4 +178,4 @@ class ChatMeeting(Base):
     chat_message = Column(Text, nullable=False)
     extracted_intent = Column(Text)  # Store as JSON string
     poll_id = Column(UUID(as_uuid=True), ForeignKey("meeting_polls.id"))
-    created_at = Column(DateTime(timezone=True), default=utc_now)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)

--- a/services/office/api/calendar.py
+++ b/services/office/api/calendar.py
@@ -115,7 +115,7 @@ async def get_user_availability(
     start_time = datetime.now(timezone.utc)
 
     logger.info(
-        f"[{request_id}] Availability request: user_id={user_id}, start={start}, end={end}, duration={duration}"
+        f"Availability request: user_id={user_id}, start={start}, end={end}, duration={duration}"
     )
 
     try:
@@ -215,13 +215,9 @@ async def get_user_availability(
                     events, provider_name = result
                     all_events.extend(events)
                     providers_used.append(provider_name)
-                    logger.info(
-                        f"[{request_id}] Provider {provider} returned {len(events)} events"
-                    )
+                    logger.info(f"Provider {provider} returned {len(events)} events")
                 except (TypeError, ValueError) as e:
-                    logger.error(
-                        f"[{request_id}] Invalid result format from {provider}: {e}"
-                    )
+                    logger.error(f"Invalid result format from {provider}: {e}")
                     provider_errors[provider] = f"Invalid result format: {e}"
 
         # Find available time slots
@@ -343,7 +339,7 @@ async def get_calendar_events(
     start_time = datetime.now(timezone.utc)
 
     logger.info(
-        f"[{request_id}] Calendar events request: user_id={user_id}, providers={providers}, limit={limit}"
+        f"Calendar events request: user_id={user_id}, providers={providers}, limit={limit}"
     )
 
     try:
@@ -415,7 +411,7 @@ async def get_calendar_events(
             "no_cache": no_cache,
         }
         cache_key = generate_cache_key(user_id, "unified", "events", cache_params)
-        logger.debug(f"[{request_id}] Generated cache key: {cache_key}")
+        logger.debug(f"Generated cache key: {cache_key}")
 
         # Check cache first
         cached_result = await cache_manager.get_from_cache(cache_key)
@@ -489,13 +485,9 @@ async def get_calendar_events(
                     events, provider_name = result
                     aggregated_events.extend(events)
                     providers_used.append(provider_name)
-                    logger.info(
-                        f"[{request_id}] Provider {provider} returned {len(events)} events"
-                    )
+                    logger.info(f"Provider {provider} returned {len(events)} events")
                 except (TypeError, ValueError) as e:
-                    logger.error(
-                        f"[{request_id}] Invalid result format from {provider}: {e}"
-                    )
+                    logger.error(f"Invalid result format from {provider}: {e}")
                     provider_errors[provider] = f"Invalid result format: {e}"
 
         # Sort events by start time
@@ -641,9 +633,7 @@ async def get_calendar_event(
         end_time = datetime.now(timezone.utc)
         response_time_ms = int((end_time - start_time).total_seconds() * 1000)
 
-        logger.info(
-            f"[{request_id}] Event detail request completed in {response_time_ms}ms"
-        )
+        logger.info(f"Event detail request completed in {response_time_ms}ms")
 
         return ApiResponse(
             success=True,
@@ -683,7 +673,7 @@ async def create_calendar_event(
     start_time = datetime.now(timezone.utc)
 
     logger.info(
-        f"[{request_id}] Create calendar event request: user_id={user_id}, "
+        f"Create calendar event request: user_id={user_id}, "
         f"title='{event_data.title}', provider={event_data.provider}"
     )
 
@@ -742,7 +732,7 @@ async def create_calendar_event(
         response_time_ms = int((end_time - start_time).total_seconds() * 1000)
 
         logger.info(
-            f"[{request_id}] Calendar event created successfully in {response_time_ms}ms via {provider}"
+            f"Calendar event created successfully in {response_time_ms}ms via {provider}"
         )
 
         return CalendarEventApiResponse(
@@ -758,7 +748,7 @@ async def create_calendar_event(
     except ValidationError:
         raise
     except Exception as e:
-        logger.error(f"[{request_id}] Create calendar event request failed: {e}")
+        logger.error(f"Create calendar event request failed: {e}")
         raise ServiceError(message=f"Failed to create calendar event: {str(e)}")
 
 
@@ -787,7 +777,7 @@ async def update_calendar_event(
     start_time = datetime.now(timezone.utc)
 
     logger.info(
-        f"[{request_id}] Update calendar event request: event_id={event_id}, user_id={user_id}, "
+        f"Update calendar event request: event_id={event_id}, user_id={user_id}, "
         f"title='{event_data.title}'"
     )
 
@@ -879,7 +869,7 @@ async def update_calendar_event(
         response_time_ms = int((end_time - start_time).total_seconds() * 1000)
 
         logger.info(
-            f"[{request_id}] Calendar event updated successfully in {response_time_ms}ms via {provider}"
+            f"Calendar event updated successfully in {response_time_ms}ms via {provider}"
         )
 
         return ApiResponse(
@@ -895,7 +885,7 @@ async def update_calendar_event(
     except ValidationError:
         raise
     except Exception as e:
-        logger.error(f"[{request_id}] Update calendar event request failed: {e}")
+        logger.error(f"Update calendar event request failed: {e}")
         raise ServiceError(message=f"Failed to update calendar event: {str(e)}")
 
 
@@ -956,13 +946,11 @@ async def create_google_event(
         # Create the event
         result = await client.create_event(calendar_id, google_event_data)
 
-        logger.info(
-            f"[{request_id}] Google Calendar event created successfully: {result.get('id')}"
-        )
+        logger.info(f"Google Calendar event created successfully: {result.get('id')}")
         return result
 
     except Exception as e:
-        logger.error(f"[{request_id}] Failed to create Google Calendar event: {e}")
+        logger.error(f"Failed to create Google Calendar event: {e}")
         raise
 
 
@@ -1032,12 +1020,12 @@ async def create_microsoft_event(
         result = await client.create_event(microsoft_event_data, event_data.calendar_id)
 
         logger.info(
-            f"[{request_id}] Microsoft Calendar event created successfully: {result.get('id')}"
+            f"Microsoft Calendar event created successfully: {result.get('id')}"
         )
         return result
 
     except Exception as e:
-        logger.error(f"[{request_id}] Failed to create Microsoft Calendar event: {e}")
+        logger.error(f"Failed to create Microsoft Calendar event: {e}")
         raise
 
 
@@ -1101,13 +1089,11 @@ async def update_google_event(
         # Update the event
         result = await client.update_event(calendar_id, event_id, google_event_data)
 
-        logger.info(
-            f"[{request_id}] Google Calendar event updated successfully: {event_id}"
-        )
+        logger.info(f"Google Calendar event updated successfully: {event_id}")
         return result
 
     except Exception as e:
-        logger.error(f"[{request_id}] Failed to update Google Calendar event: {e}")
+        logger.error(f"Failed to update Google Calendar event: {e}")
         raise
 
 
@@ -1182,13 +1168,11 @@ async def update_microsoft_event(
         # Update the event
         result = await client.update_event(event_id, microsoft_event_data, calendar_id)
 
-        logger.info(
-            f"[{request_id}] Microsoft Calendar event updated successfully: {event_id}"
-        )
+        logger.info(f"Microsoft Calendar event updated successfully: {event_id}")
         return result
 
     except Exception as e:
-        logger.error(f"[{request_id}] Failed to update Microsoft Calendar event: {e}")
+        logger.error(f"Failed to update Microsoft Calendar event: {e}")
         raise
 
 
@@ -1215,7 +1199,7 @@ async def delete_calendar_event(
     start_time = datetime.now(timezone.utc)
 
     logger.info(
-        f"[{request_id}] Delete calendar event request: event_id={event_id}, user_id={user_id}"
+        f"Delete calendar event request: event_id={event_id}, user_id={user_id}"
     )
 
     try:
@@ -1258,7 +1242,7 @@ async def delete_calendar_event(
         response_time_ms = int((end_time - start_time).total_seconds() * 1000)
 
         logger.info(
-            f"[{request_id}] Calendar event deleted successfully in {response_time_ms}ms via {provider}"
+            f"Calendar event deleted successfully in {response_time_ms}ms via {provider}"
         )
 
         return ApiResponse(
@@ -1274,7 +1258,7 @@ async def delete_calendar_event(
     except AuthError:
         raise
     except Exception as e:
-        logger.error(f"[{request_id}] Delete calendar event request failed: {e}")
+        logger.error(f"Delete calendar event request failed: {e}")
         raise ServiceError(message=f"Failed to delete calendar event: {str(e)}")
 
 
@@ -1297,12 +1281,10 @@ async def delete_google_event(
         # Delete the event
         await client.delete_event(calendar_id, event_id)
 
-        logger.info(
-            f"[{request_id}] Google Calendar event deleted successfully: {event_id}"
-        )
+        logger.info(f"Google Calendar event deleted successfully: {event_id}")
 
     except Exception as e:
-        logger.error(f"[{request_id}] Failed to delete Google Calendar event: {e}")
+        logger.error(f"Failed to delete Google Calendar event: {e}")
         raise
 
 
@@ -1325,12 +1307,10 @@ async def delete_microsoft_event(
         # Delete the event
         await client.delete_event(event_id, calendar_id)
 
-        logger.info(
-            f"[{request_id}] Microsoft Calendar event deleted successfully: {event_id}"
-        )
+        logger.info(f"Microsoft Calendar event deleted successfully: {event_id}")
 
     except Exception as e:
-        logger.error(f"[{request_id}] Failed to delete Microsoft Calendar event: {e}")
+        logger.error(f"Failed to delete Microsoft Calendar event: {e}")
         raise
 
 
@@ -1365,18 +1345,14 @@ async def fetch_provider_events(
     try:
         # Get API client for provider with calendar-specific scopes
         calendar_scopes = _get_calendar_scopes(provider)
-        logger.debug(
-            f"[{request_id}] Creating {provider} client with scopes: {calendar_scopes}"
-        )
+        logger.debug(f"Creating {provider} client with scopes: {calendar_scopes}")
         client = await api_client_factory.create_client(
             user_id, provider, calendar_scopes
         )
         if client is None:
-            logger.error(
-                f"[{request_id}] Failed to create API client for provider {provider}"
-            )
+            logger.error(f"Failed to create API client for provider {provider}")
             raise ValueError(f"Failed to create API client for provider {provider}")
-        logger.debug(f"[{request_id}] Successfully created {provider} client")
+        logger.debug(f"Successfully created {provider} client")
 
         # Use client as async context manager
         async with client:
@@ -1423,7 +1399,7 @@ async def fetch_provider_events(
 
                     except Exception as calendar_error:
                         logger.warning(
-                            f"[{request_id}] Failed to fetch from Google calendar {calendar_id}: {calendar_error}"
+                            f"Failed to fetch from Google calendar {calendar_id}: {calendar_error}"
                         )
                         continue
 
@@ -1434,7 +1410,7 @@ async def fetch_provider_events(
 
                 # Fetch events from Outlook
                 logger.debug(
-                    f"[{request_id}] Fetching Microsoft events with start_time={start_dt.isoformat()}, end_time={end_dt.isoformat()}"
+                    f"Fetching Microsoft events with start_time={start_dt.isoformat()}, end_time={end_dt.isoformat()}"
                 )
                 events_response = await microsoft_client.get_events(
                     calendar_id=None,  # Use primary calendar
@@ -1445,9 +1421,7 @@ async def fetch_provider_events(
                     order_by="start/dateTime asc",
                 )
                 events = events_response.get("value", [])
-                logger.debug(
-                    f"[{request_id}] Microsoft API returned {len(events)} events"
-                )
+                logger.debug(f"Microsoft API returned {len(events)} events")
 
                 # Normalize events
                 normalized_events = []
@@ -1481,7 +1455,7 @@ async def fetch_provider_events(
                 raise ValueError(f"Unsupported provider: {provider}")
 
             logger.info(
-                f"[{request_id}] Successfully fetched {len(normalized_events)} events from {provider}"
+                f"Successfully fetched {len(normalized_events)} events from {provider}"
             )
             return normalized_events, provider
 
@@ -1577,9 +1551,7 @@ async def fetch_single_event(
                 raise ValueError(f"Unsupported provider: {provider}")
 
     except Exception as e:
-        logger.error(
-            f"[{request_id}] Failed to fetch event {original_event_id} from {provider}: {e}"
-        )
+        logger.error(f"Failed to fetch event {original_event_id} from {provider}: {e}")
         return None
 
 

--- a/services/office/api/email.py
+++ b/services/office/api/email.py
@@ -7,14 +7,13 @@ Internal/service endpoints, if any, should be under /internal and require API ke
 """
 
 import asyncio
-import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, cast
 
 from fastapi import APIRouter, Depends, Path, Query, Request
 
 from services.common.http_errors import NotFoundError, ServiceError, ValidationError
-from services.common.logging_config import get_logger
+from services.common.logging_config import get_logger, request_id_var
 from services.office.core.api_client_factory import APIClientFactory
 from services.office.core.auth import service_permission_required
 from services.office.core.cache_manager import cache_manager, generate_cache_key
@@ -54,6 +53,17 @@ async def get_user_id_from_gateway(request: Request) -> str:
     if not user_id:
         raise ValidationError(message="X-User-Id header is required", field="X-User-Id")
     return user_id
+
+
+def get_request_id() -> str:
+    """
+    Get the current request ID from context or generate a fallback.
+    """
+    request_id = request_id_var.get()
+    if not request_id or request_id == "uninitialized":
+        # Fallback for cases where middleware hasn't set the context
+        return "no-request-id"
+    return request_id
 
 
 @router.get("/messages", response_model=EmailMessageList)
@@ -107,11 +117,11 @@ async def get_email_messages(
         EmailMessageList with aggregated email messages
     """
     user_id = await get_user_id_from_gateway(request)
-    request_id = str(uuid.uuid4())
+    request_id = get_request_id()
     start_time = datetime.now(timezone.utc)
 
     logger.info(
-        f"[{request_id}] Email messages request: user_id={user_id}, providers={providers}, limit={limit}"
+        f"Email messages request: user_id={user_id}, providers={providers}, limit={limit}"
     )
 
     try:
@@ -129,7 +139,7 @@ async def get_email_messages(
             if provider_name.lower() in ["google", "microsoft"]:
                 valid_providers.append(provider_name.lower())
             else:
-                logger.warning(f"[{request_id}] Invalid provider: {provider_name}")
+                logger.warning(f"Invalid provider: {provider_name}")
 
         if not valid_providers:
             raise ValidationError(message="No valid providers specified")
@@ -150,7 +160,7 @@ async def get_email_messages(
         # Check cache first
         cached_result = await cache_manager.get_from_cache(cache_key)
         if cached_result and not no_cache:
-            logger.info(f"[{request_id}] Cache hit for email messages")
+            logger.info("Cache hit for email messages")
             return EmailMessageList(
                 success=True, data=cached_result, cache_hit=True, request_id=request_id
             )
@@ -183,9 +193,7 @@ async def get_email_messages(
             provider_name = valid_providers[i]
 
             if isinstance(result, Exception):
-                logger.error(
-                    f"[{request_id}] Provider {provider_name} failed: {result}"
-                )
+                logger.error(f"Provider {provider_name} failed: {result}")
                 provider_errors[provider_name] = str(result)
             elif result is not None and not isinstance(result, BaseException):
                 try:
@@ -194,12 +202,10 @@ async def get_email_messages(
                     aggregated_messages.extend(messages)
                     providers_used.append(provider_name)
                     logger.info(
-                        f"[{request_id}] Provider {provider_name} returned {len(messages)} messages"
+                        f"Provider {provider_name} returned {len(messages)} messages"
                     )
                 except (TypeError, ValueError) as e:
-                    logger.error(
-                        f"[{request_id}] Invalid result format from {provider_name}: {e}"
-                    )
+                    logger.error(f"Invalid result format from {provider_name}: {e}")
                     provider_errors[provider_name] = f"Invalid result format: {e}"
 
         # Sort messages by date (newest first)
@@ -230,7 +236,7 @@ async def get_email_messages(
             await cache_manager.set_to_cache(cache_key, response_data, ttl_seconds=900)
         else:
             logger.info(
-                f"[{request_id}] Not caching response due to no successful providers",
+                "Not caching response due to no successful providers",
                 extra={
                     "providers_used": providers_used,
                     "provider_errors": provider_errors,
@@ -241,9 +247,7 @@ async def get_email_messages(
         end_time = datetime.now(timezone.utc)
         response_time_ms = int((end_time - start_time).total_seconds() * 1000)
 
-        logger.info(
-            f"[{request_id}] Email messages request completed in {response_time_ms}ms"
-        )
+        logger.info(f"Email messages request completed in {response_time_ms}ms")
 
         return EmailMessageList(
             success=True,
@@ -258,7 +262,7 @@ async def get_email_messages(
     except ValidationError:
         raise
     except Exception as e:
-        logger.error(f"[{request_id}] Email messages request failed: {e}")
+        logger.error(f"Email messages request failed: {e}")
         raise ServiceError(message=f"Failed to fetch email messages: {str(e)}")
 
 
@@ -290,12 +294,10 @@ async def get_email_folders(
         EmailFolderList with aggregated email folders
     """
     user_id = await get_user_id_from_gateway(request)
-    request_id = str(uuid.uuid4())
+    request_id = get_request_id()
     start_time = datetime.now(timezone.utc)
 
-    logger.info(
-        f"[{request_id}] Email folders request: user_id={user_id}, providers={providers}"
-    )
+    logger.info(f"Email folders request: user_id={user_id}, providers={providers}")
 
     try:
         # Default to all providers if not specified
@@ -308,7 +310,7 @@ async def get_email_folders(
             if provider_name.lower() in ["google", "microsoft"]:
                 valid_providers.append(provider_name.lower())
             else:
-                logger.warning(f"[{request_id}] Invalid provider: {provider_name}")
+                logger.warning(f"Invalid provider: {provider_name}")
 
         if not valid_providers:
             raise ValidationError(message="No valid providers specified")
@@ -323,7 +325,7 @@ async def get_email_folders(
         # Check cache first
         cached_result = await cache_manager.get_from_cache(cache_key)
         if cached_result and not no_cache:
-            logger.info(f"[{request_id}] Cache hit for email folders")
+            logger.info("Cache hit for email folders")
             return EmailFolderList(
                 success=True, data=cached_result, cache_hit=True, request_id=request_id
             )
@@ -350,9 +352,7 @@ async def get_email_folders(
             provider_name = valid_providers[i]
 
             if isinstance(result, Exception):
-                logger.error(
-                    f"[{request_id}] Provider {provider_name} failed: {result}"
-                )
+                logger.error(f"Provider {provider_name} failed: {result}")
                 provider_errors[provider_name] = str(result)
             elif result is not None and not isinstance(result, BaseException):
                 try:
@@ -361,12 +361,10 @@ async def get_email_folders(
                     aggregated_folders.extend(folders)
                     providers_used.append(provider_name)
                     logger.info(
-                        f"[{request_id}] Provider {provider_name} returned {len(folders)} folders"
+                        f"Provider {provider_name} returned {len(folders)} folders"
                     )
                 except (TypeError, ValueError) as e:
-                    logger.error(
-                        f"[{request_id}] Invalid result format from {provider_name}: {e}"
-                    )
+                    logger.error(f"Invalid result format from {provider_name}: {e}")
                     provider_errors[provider_name] = f"Invalid result format: {e}"
 
         # Remove duplicates based on label
@@ -395,7 +393,7 @@ async def get_email_folders(
         end_time = datetime.now(timezone.utc)
         duration = (end_time - start_time).total_seconds()
         logger.info(
-            f"[{request_id}] Email folders request completed in {duration:.2f}s: "
+            f"Email folders request completed in {duration:.2f}s: "
             f"{len(unique_folders)} folders from {len(providers_used)} providers"
         )
 
@@ -404,7 +402,7 @@ async def get_email_folders(
         )
 
     except Exception as e:
-        logger.error(f"[{request_id}] Error fetching email folders: {e}")
+        logger.error(f"Error fetching email folders: {e}")
         raise ServiceError(
             message="Failed to fetch email folders",
             details={"error": str(e)},
@@ -435,11 +433,11 @@ async def get_email_message(
         EmailMessageList with the specific email message
     """
     user_id = await get_user_id_from_gateway(request)
-    request_id = str(uuid.uuid4())
+    request_id = get_request_id()
     start_time = datetime.now(timezone.utc)
 
     logger.info(
-        f"[{request_id}] Email message detail request: message_id={message_id}, user_id={user_id}"
+        f"Email message detail request: message_id={message_id}, user_id={user_id}"
     )
 
     try:
@@ -455,7 +453,7 @@ async def get_email_message(
         # Check cache first
         cached_result = await cache_manager.get_from_cache(cache_key)
         if cached_result:
-            logger.info(f"[{request_id}] Cache hit for message detail")
+            logger.info("Cache hit for message detail")
             return EmailMessageList(
                 success=True, data=cached_result, cache_hit=True, request_id=request_id
             )
@@ -486,9 +484,7 @@ async def get_email_message(
         end_time = datetime.now(timezone.utc)
         response_time_ms = int((end_time - start_time).total_seconds() * 1000)
 
-        logger.info(
-            f"[{request_id}] Message detail request completed in {response_time_ms}ms"
-        )
+        logger.info(f"Message detail request completed in {response_time_ms}ms")
 
         return EmailMessageList(
             success=True,
@@ -503,7 +499,7 @@ async def get_email_message(
     except ValidationError:
         raise
     except Exception as e:
-        logger.error(f"[{request_id}] Message detail request failed: {e}")
+        logger.error(f"Message detail request failed: {e}")
         raise ServiceError(message=f"Failed to fetch message: {str(e)}")
 
 
@@ -527,11 +523,11 @@ async def send_email(
         SendEmailResponse with sent message details
     """
     user_id = await get_user_id_from_gateway(request)
-    request_id = str(uuid.uuid4())
+    request_id = get_request_id()
     start_time = datetime.now(timezone.utc)
 
     logger.info(
-        f"[{request_id}] Send email request: user_id={user_id}, "
+        f"Send email request: user_id={user_id}, "
         f"to={[addr.email for addr in email_data.to]}, subject='{email_data.subject}'"
     )
 
@@ -588,9 +584,7 @@ async def send_email(
         end_time = datetime.now(timezone.utc)
         response_time_ms = int((end_time - start_time).total_seconds() * 1000)
 
-        logger.info(
-            f"[{request_id}] Email sent successfully in {response_time_ms}ms via {provider}"
-        )
+        logger.info(f"Email sent successfully in {response_time_ms}ms via {provider}")
 
         return SendEmailResponse(
             success=True,
@@ -601,7 +595,7 @@ async def send_email(
     except ValidationError:
         raise
     except Exception as e:
-        logger.error(f"[{request_id}] Send email request failed: {e}")
+        logger.error(f"Send email request failed: {e}")
         raise ServiceError(message=f"Failed to send email: {str(e)}")
 
 
@@ -645,13 +639,11 @@ async def send_gmail_message(
         # Send the message
         result = await client.send_message(message_content)
 
-        logger.info(
-            f"[{request_id}] Gmail message sent successfully: {result.get('id')}"
-        )
+        logger.info(f"Gmail message sent successfully: {result.get('id')}")
         return result
 
     except Exception as e:
-        logger.error(f"[{request_id}] Failed to send Gmail message: {e}")
+        logger.error(f"Failed to send Gmail message: {e}")
         raise
 
 
@@ -728,11 +720,11 @@ async def send_outlook_message(
         # We'll return a simple confirmation
         result = {"id": f"outlook_sent_{request_id}", "status": "sent"}
 
-        logger.info(f"[{request_id}] Outlook message sent successfully")
+        logger.info("Outlook message sent successfully")
         return result
 
     except Exception as e:
-        logger.error(f"[{request_id}] Failed to send Outlook message: {e}")
+        logger.error(f"Failed to send Outlook message: {e}")
         raise
 
 
@@ -905,12 +897,12 @@ async def fetch_provider_emails(
                 raise ValidationError(message=f"Unsupported provider: {provider}")
 
             logger.info(
-                f"[{request_id}] Successfully fetched {len(normalized_messages)} messages from {provider}"
+                f"Successfully fetched {len(normalized_messages)} messages from {provider}"
             )
             return normalized_messages, provider
 
     except Exception as e:
-        logger.error(f"[{request_id}] Error fetching emails from {provider}: {e}")
+        logger.error(f"Error fetching emails from {provider}: {e}")
         raise
 
 
@@ -1092,7 +1084,7 @@ async def fetch_provider_folders(
         return normalized_folders, provider
 
     except Exception as e:
-        logger.error(f"[{request_id}] Error fetching folders from {provider}: {e}")
+        logger.error(f"Error fetching folders from {provider}: {e}")
         raise
 
 
@@ -1165,7 +1157,7 @@ async def fetch_single_message(
 
     except Exception as e:
         logger.error(
-            f"[{request_id}] Failed to fetch message {original_message_id} from {provider}: {e}"
+            f"Failed to fetch message {original_message_id} from {provider}: {e}"
         )
         return None
 

--- a/services/office/api/files.py
+++ b/services/office/api/files.py
@@ -112,7 +112,7 @@ async def get_files(
     start_time = datetime.now(timezone.utc)
 
     logger.info(
-        f"[{request_id}] Files request: user_id={user_id}, providers={providers}, limit={limit}"
+        f"Files request: user_id={user_id}, providers={providers}, limit={limit}"
     )
 
     try:
@@ -126,7 +126,7 @@ async def get_files(
             if provider.lower() in ["google", "microsoft"]:
                 valid_providers.append(provider.lower())
             else:
-                logger.warning(f"[{request_id}] Invalid provider: {provider}")
+                logger.warning(f"Invalid provider: {provider}")
 
         if not valid_providers:
             raise ValidationError(message="No valid providers specified")
@@ -146,7 +146,7 @@ async def get_files(
         # Check cache first (shortened TTL for files as they change frequently)
         cached_result = await cache_manager.get_from_cache(cache_key)
         if cached_result:
-            logger.info(f"[{request_id}] Cache hit for files")
+            logger.info("Cache hit for files")
             return ApiResponse(
                 success=True, data=cached_result, cache_hit=True, request_id=request_id
             )
@@ -158,7 +158,7 @@ async def get_files(
 
         async def fetch_from_provider(provider: str) -> None:
             try:
-                logger.info(f"[{request_id}] Fetching files from {provider}")
+                logger.info(f"Fetching files from {provider}")
 
                 # Get API client for the provider
                 client = await api_client_factory.create_client(user_id, provider)
@@ -209,13 +209,13 @@ async def get_files(
                                     all_files.append(normalized_file)
                                 except Exception as norm_error:
                                     logger.error(
-                                        f"[{request_id}] Failed to normalize Google Drive file: {norm_error}"
+                                        f"Failed to normalize Google Drive file: {norm_error}"
                                     )
                                     continue
 
                         providers_used.append("google")
                         logger.info(
-                            f"[{request_id}] Successfully fetched {len(response.get('files', []))} files from Google"
+                            f"Successfully fetched {len(response.get('files', []))} files from Google"
                         )
 
                     elif provider == "microsoft":
@@ -263,20 +263,18 @@ async def get_files(
                                     all_files.append(normalized_file)
                                 except Exception as norm_error:
                                     logger.error(
-                                        f"[{request_id}] Failed to normalize Microsoft Drive file: {norm_error}"
+                                        f"Failed to normalize Microsoft Drive file: {norm_error}"
                                     )
                                     continue
 
                         providers_used.append("microsoft")
                         logger.info(
-                            f"[{request_id}] Successfully fetched {len(response.get('value', []))} files from Microsoft"
+                            f"Successfully fetched {len(response.get('value', []))} files from Microsoft"
                         )
 
             except Exception as e:
                 error_msg = str(e)
-                logger.error(
-                    f"[{request_id}] Failed to fetch files from {provider}: {error_msg}"
-                )
+                logger.error(f"Failed to fetch files from {provider}: {error_msg}")
                 provider_errors[provider] = error_msg
 
         # Execute provider requests in parallel
@@ -322,7 +320,7 @@ async def get_files(
             await cache_manager.set_to_cache(cache_key, response_data, ttl_seconds=300)
         else:
             logger.info(
-                f"[{request_id}] Not caching response due to no successful providers",
+                "Not caching response due to no successful providers",
                 extra={
                     "providers_used": providers_used,
                     "provider_errors": provider_errors,
@@ -334,7 +332,7 @@ async def get_files(
         response_time_ms = int((end_time - start_time).total_seconds() * 1000)
 
         logger.info(
-            f"[{request_id}] Files request completed in {response_time_ms}ms: {len(all_files)} files from {len(providers_used)} providers"
+            f"Files request completed in {response_time_ms}ms: {len(all_files)} files from {len(providers_used)} providers"
         )
 
         # Ensure all collection values are not None for mypy
@@ -348,7 +346,7 @@ async def get_files(
     except ValidationError:
         raise
     except Exception as e:
-        logger.error(f"[{request_id}] Files request failed: {e}")
+        logger.error(f"Files request failed: {e}")
         raise ServiceError(message=f"Failed to fetch files: {str(e)}")
 
 
@@ -387,7 +385,7 @@ async def search_files(
     start_time = datetime.now(timezone.utc)
 
     logger.info(
-        f"[{request_id}] File search request: user_id={user_id}, query='{q}', providers={providers}"
+        f"File search request: user_id={user_id}, query='{q}', providers={providers}"
     )
 
     try:
@@ -401,7 +399,7 @@ async def search_files(
             if provider.lower() in ["google", "microsoft"]:
                 valid_providers.append(provider.lower())
             else:
-                logger.warning(f"[{request_id}] Invalid provider: {provider}")
+                logger.warning(f"Invalid provider: {provider}")
 
         if not valid_providers:
             raise ValidationError(message="No valid providers specified")
@@ -418,7 +416,7 @@ async def search_files(
         # Check cache first (5 minute TTL for search results)
         cached_result = await cache_manager.get_from_cache(cache_key)
         if cached_result:
-            logger.info(f"[{request_id}] Cache hit for file search")
+            logger.info("Cache hit for file search")
             return ApiResponse(
                 success=True, data=cached_result, cache_hit=True, request_id=request_id
             )
@@ -430,7 +428,7 @@ async def search_files(
 
         async def search_provider(provider: str) -> None:
             try:
-                logger.info(f"[{request_id}] Searching files in {provider}")
+                logger.info(f"Searching files in {provider}")
 
                 # Get API client for the provider
                 client = await api_client_factory.create_client(user_id, provider)
@@ -471,13 +469,13 @@ async def search_files(
                                     all_results.append(normalized_file)
                                 except Exception as norm_error:
                                     logger.error(
-                                        f"[{request_id}] Failed to normalize Google search result: {norm_error}"
+                                        f"Failed to normalize Google search result: {norm_error}"
                                     )
                                     continue
 
                         providers_used.append("google")
                         logger.info(
-                            f"[{request_id}] Successfully searched Google: {len(response.get('files', []))} results"
+                            f"Successfully searched Google: {len(response.get('files', []))} results"
                         )
 
                     elif provider == "microsoft":
@@ -513,20 +511,18 @@ async def search_files(
                                     all_results.append(normalized_file)
                                 except Exception as norm_error:
                                     logger.error(
-                                        f"[{request_id}] Failed to normalize Microsoft search result: {norm_error}"
+                                        f"Failed to normalize Microsoft search result: {norm_error}"
                                     )
                                     continue
 
                         providers_used.append("microsoft")
                         logger.info(
-                            f"[{request_id}] Successfully searched Microsoft: {len(response.get('value', []))} results"
+                            f"Successfully searched Microsoft: {len(response.get('value', []))} results"
                         )
 
             except Exception as e:
                 error_msg = str(e)
-                logger.error(
-                    f"[{request_id}] Failed to search files in {provider}: {error_msg}"
-                )
+                logger.error(f"Failed to search files in {provider}: {error_msg}")
                 provider_errors[provider] = error_msg
 
         # Execute provider searches in parallel
@@ -556,7 +552,7 @@ async def search_files(
             await cache_manager.set_to_cache(cache_key, response_data, ttl_seconds=300)
         else:
             logger.info(
-                f"[{request_id}] Not caching search response due to no successful providers",
+                "Not caching search response due to no successful providers",
                 extra={
                     "providers_used": providers_used,
                     "provider_errors": provider_errors,
@@ -568,7 +564,7 @@ async def search_files(
         response_time_ms = int((end_time - start_time).total_seconds() * 1000)
 
         logger.info(
-            f"[{request_id}] File search completed in {response_time_ms}ms: {len(all_results)} results from {len(providers_used)} providers"
+            f"File search completed in {response_time_ms}ms: {len(all_results)} results from {len(providers_used)} providers"
         )
 
         return ApiResponse(
@@ -578,7 +574,7 @@ async def search_files(
     except ValidationError:
         raise
     except Exception as e:
-        logger.error(f"[{request_id}] File search failed: {e}")
+        logger.error(f"File search failed: {e}")
         raise ServiceError(message=f"Failed to search files: {str(e)}")
 
 
@@ -608,15 +604,13 @@ async def get_file(
     request_id = get_request_id()
     start_time = datetime.now(timezone.utc)
 
-    logger.info(
-        f"[{request_id}] File detail request: file_id={file_id}, user_id={user_id}"
-    )
+    logger.info(f"File detail request: file_id={file_id}, user_id={user_id}")
 
     try:
         # Parse provider from file_id
         provider, original_file_id = parse_file_id(file_id)
 
-        logger.info(f"[{request_id}] Fetching file from {provider}: {original_file_id}")
+        logger.info(f"Fetching file from {provider}: {original_file_id}")
 
         # Get API client for the provider
         client = await api_client_factory.create_client(user_id, provider)
@@ -676,7 +670,7 @@ async def get_file(
                 response_time_ms = int((end_time - start_time).total_seconds() * 1000)
 
                 logger.info(
-                    f"[{request_id}] File detail request completed in {response_time_ms}ms: {normalized_file.name}"
+                    f"File detail request completed in {response_time_ms}ms: {normalized_file.name}"
                 )
 
                 return ApiResponse(
@@ -689,9 +683,7 @@ async def get_file(
 
             except Exception as e:
                 error_msg = str(e)
-                logger.error(
-                    f"[{request_id}] Failed to fetch file from {provider}: {error_msg}"
-                )
+                logger.error(f"Failed to fetch file from {provider}: {error_msg}")
 
                 # Return error response
                 response_data = {
@@ -716,7 +708,7 @@ async def get_file(
     except ValidationError:
         raise
     except Exception as e:
-        logger.error(f"[{request_id}] File detail request failed: {e}")
+        logger.error(f"File detail request failed: {e}")
         raise ServiceError(message=f"Failed to fetch file: {str(e)}")
 
 


### PR DESCRIPTION
This resolves the issue where office service was generating duplicate trace IDs instead of using the trace ID from the incoming request, enabling proper distributed tracing across the system.

- Replace uuid.uuid4() calls with get_request_id() function that extracts trace ID from request context
- Add request_id_var import to all office API files (email, calendar, files)
- Remove trace IDs from log message content since they're already included in structured logging
- Fix distributed tracing by propagating the original request ID instead of creating new ones