### PR TITLE
feat: migrate shipments service from integer IDs to UUIDs

### DIFF
--- a/frontend/components/packages/AddPackageModal.tsx
+++ b/frontend/components/packages/AddPackageModal.tsx
@@ -10,7 +10,7 @@ export interface TrackingEvent {
 }
 
 export interface Package {
-    id?: number;
+    id?: string; // Changed from number to string (UUID)
     tracking_number: string;
     carrier: string;
     status: PackageStatus;
@@ -25,7 +25,6 @@ export interface Package {
     email_message_id?: string;
     labels?: (string | { name: string })[];
     events?: TrackingEvent[];
-    [key: string]: unknown;
 }
 
 const initialState: Package = {

--- a/frontend/components/packages/LabelPicker.tsx
+++ b/frontend/components/packages/LabelPicker.tsx
@@ -1,5 +1,5 @@
 export default function LabelPicker({ labels, selectedLabels, onChange }: {
-    labels: { id: number, name: string, color: string }[],
+    labels: { id: string, name: string, color: string }[],
     selectedLabels: string[],
     onChange: (labels: string[]) => void,
 }) {

--- a/frontend/components/packages/PackageDashboard.tsx
+++ b/frontend/components/packages/PackageDashboard.tsx
@@ -49,7 +49,7 @@ export default function PackageDashboard() {
     const [searchTerm, setSearchTerm] = useState('');
     const [sortField, setSortField] = useState('estimated_delivery');
     const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
-    const [editingCell, setEditingCell] = useState<{ id: number; field: string } | null>(null);
+    const [editingCell, setEditingCell] = useState<{ id: string; field: string } | null>(null); // Changed from number to string (UUID)
     const [selectedPackage, setSelectedPackage] = useState<Package | null>(null);
     const [selectedStatusFilters, setSelectedStatusFilters] = useState<string[]>([]);
     const [selectedCarrierFilters] = useState<string[]>([]);
@@ -117,7 +117,7 @@ export default function PackageDashboard() {
         }
     };
 
-    const handleCellEdit = (id: number, field: string, value: string) => {
+    const handleCellEdit = (id: string, field: string, value: string) => { // Changed from number to string (UUID)
         setPackages(packages.map((p) => (p.id === id ? { ...p, [field]: value } : p)));
         setEditingCell(null);
     };

--- a/frontend/components/packages/PackageDashboard.tsx
+++ b/frontend/components/packages/PackageDashboard.tsx
@@ -93,8 +93,8 @@ export default function PackageDashboard() {
             return matchesSearch && matchesStatus && matchesCarrier && matchesDate;
         });
         filtered.sort((a, b) => {
-            const aValue = a[sortField] as string | number | undefined;
-            const bValue = b[sortField] as string | number | undefined;
+            const aValue = a[sortField as keyof Package] as string | number | undefined;
+            const bValue = b[sortField as keyof Package] as string | number | undefined;
             if (typeof aValue === 'string' && typeof bValue === 'string') {
                 return sortDirection === 'asc' ? aValue.localeCompare(bValue) : bValue.localeCompare(aValue);
             }

--- a/frontend/components/packages/PackageList.tsx
+++ b/frontend/components/packages/PackageList.tsx
@@ -102,52 +102,52 @@ export default function PackageList({
                         </TableRow>
                     ) : (
                         packages.map(pkg => (
-                            <TableRow key={pkg.id ?? 0} className="hover:bg-blue-50 cursor-pointer" onClick={() => onRowClick(pkg)}>
+                            <TableRow key={pkg.id} className="hover:bg-blue-50 cursor-pointer" onClick={() => onRowClick(pkg)}>
                                 <TableCell onClick={e => e.stopPropagation()}>
-                                    {editingCell?.id === (pkg.id ?? 0) && editingCell?.field === 'tracking_number' ? (
+                                    {editingCell?.id === pkg.id && editingCell?.field === 'tracking_number' ? (
                                         <Input
                                             defaultValue={pkg.tracking_number}
-                                            onBlur={e => onCellEdit(pkg.id ?? 0, 'tracking_number', e.target.value)}
+                                            onBlur={e => onCellEdit(pkg.id!, 'tracking_number', e.target.value)}
                                             onKeyDown={e => {
-                                                if (e.key === 'Enter') onCellEdit(pkg.id ?? 0, 'tracking_number', e.currentTarget.value);
+                                                if (e.key === 'Enter') onCellEdit(pkg.id!, 'tracking_number', e.currentTarget.value);
                                                 if (e.key === 'Escape') setEditingCell(null);
                                             }}
                                             autoFocus
                                         />
                                     ) : (
-                                        <span className="cursor-pointer" onClick={() => setEditingCell({ id: pkg.id ?? 0, field: 'tracking_number' })}>{pkg.tracking_number}</span>
+                                        <span className="cursor-pointer" onClick={() => setEditingCell({ id: pkg.id!, field: 'tracking_number' })}>{pkg.tracking_number}</span>
                                     )}
                                 </TableCell>
                                 <TableCell><Badge>{pkg.status}</Badge></TableCell>
                                 <TableCell onClick={e => e.stopPropagation()}>
-                                    {editingCell?.id === (pkg.id ?? 0) && editingCell?.field === 'estimated_delivery' ? (
+                                    {editingCell?.id === pkg.id && editingCell?.field === 'estimated_delivery' ? (
                                         <Input
                                             type="date"
                                             defaultValue={pkg.estimated_delivery}
-                                            onBlur={e => onCellEdit(pkg.id ?? 0, 'estimated_delivery', e.target.value)}
+                                            onBlur={e => onCellEdit(pkg.id!, 'estimated_delivery', e.target.value)}
                                             onKeyDown={e => {
-                                                if (e.key === 'Enter') onCellEdit(pkg.id ?? 0, 'estimated_delivery', e.currentTarget.value);
+                                                if (e.key === 'Enter') onCellEdit(pkg.id!, 'estimated_delivery', e.currentTarget.value);
                                                 if (e.key === 'Escape') setEditingCell(null);
                                             }}
                                             autoFocus
                                         />
                                     ) : (
-                                        <span className="cursor-pointer" onClick={() => setEditingCell({ id: pkg.id ?? 0, field: 'estimated_delivery' })}>{pkg.estimated_delivery}</span>
+                                        <span className="cursor-pointer" onClick={() => setEditingCell({ id: pkg.id!, field: 'estimated_delivery' })}>{pkg.estimated_delivery}</span>
                                     )}
                                 </TableCell>
                                 <TableCell onClick={e => e.stopPropagation()}>
-                                    {editingCell?.id === (pkg.id ?? 0) && editingCell?.field === 'package_description' ? (
+                                    {editingCell?.id === pkg.id && editingCell?.field === 'package_description' ? (
                                         <Input
                                             defaultValue={pkg.package_description}
-                                            onBlur={e => onCellEdit(pkg.id ?? 0, 'package_description', e.target.value)}
+                                            onBlur={e => onCellEdit(pkg.id!, 'package_description', e.target.value)}
                                             onKeyDown={e => {
-                                                if (e.key === 'Enter') onCellEdit(pkg.id ?? 0, 'package_description', e.currentTarget.value);
+                                                if (e.key === 'Enter') onCellEdit(pkg.id!, 'package_description', e.currentTarget.value);
                                                 if (e.key === 'Escape') setEditingCell(null);
                                             }}
                                             autoFocus
                                         />
                                     ) : (
-                                        <span className="cursor-pointer" onClick={() => setEditingCell({ id: pkg.id ?? 0, field: 'package_description' })}>{pkg.package_description}</span>
+                                        <span className="cursor-pointer" onClick={() => setEditingCell({ id: pkg.id!, field: 'package_description' })}>{pkg.package_description}</span>
                                     )}
                                 </TableCell>
                                 <TableCell>

--- a/frontend/components/packages/PackageList.tsx
+++ b/frontend/components/packages/PackageList.tsx
@@ -59,9 +59,9 @@ export default function PackageList({
 }: {
     packages: Package[],
     onSort: (field: string) => void,
-    editingCell: { id: number; field: string } | null,
-    setEditingCell: (cell: { id: number; field: string } | null) => void,
-    onCellEdit: (id: number, field: string, value: string) => void,
+    editingCell: { id: string; field: string } | null,
+    setEditingCell: (cell: { id: string; field: string } | null) => void,
+    onCellEdit: (id: string, field: string, value: string) => void,
     onRowClick: (pkg: Package) => void,
     selectedStatusFilters: string[],
     onStatusFilterChange: (values: string[]) => void,

--- a/frontend/lib/gateway-client.ts
+++ b/frontend/lib/gateway-client.ts
@@ -479,7 +479,7 @@ export class GatewayClient {
         tracking_link?: string;
         email_message_id?: string;
     }): Promise<{
-        id: number;
+        id: string;
         tracking_number: string;
         carrier: string;
         status: PackageStatus;
@@ -505,7 +505,7 @@ export class GatewayClient {
         carrier?: string;
     }): Promise<{
         data: Array<{
-            id: number;
+            id: string;
             tracking_number: string;
             carrier: string;
             status: PackageStatus;
@@ -541,8 +541,8 @@ export class GatewayClient {
         return this.request(url);
     }
 
-    async getPackage(id: number): Promise<{
-        id: number;
+    async getPackage(id: string): Promise<{
+        id: string;
         tracking_number: string;
         carrier: string;
         status: PackageStatus;
@@ -560,8 +560,8 @@ export class GatewayClient {
         return this.request(`/api/v1/shipments/packages/${id}`);
     }
 
-    async updatePackage(id: number, packageData: Record<string, unknown>): Promise<{
-        id: number;
+    async updatePackage(id: string, packageData: Record<string, unknown>): Promise<{
+        id: string;
         tracking_number: string;
         carrier: string;
         status: PackageStatus;
@@ -582,17 +582,17 @@ export class GatewayClient {
         });
     }
 
-    async deletePackage(id: number): Promise<void> {
+    async deletePackage(id: string): Promise<void> {
         return this.request(`/api/v1/shipments/packages/${id}`, {
             method: 'DELETE',
         });
     }
 
-    async refreshPackage(id: number): Promise<{
+    async refreshPackage(id: string): Promise<{
         success: boolean;
         message: string;
         updated_data?: Partial<{
-            id: number;
+            id: string;
             tracking_number: string;
             carrier: string;
             status: PackageStatus;
@@ -613,8 +613,8 @@ export class GatewayClient {
         });
     }
 
-    async getTrackingEvents(packageId: number): Promise<Array<{
-        id: number;
+    async getTrackingEvents(packageId: string): Promise<Array<{
+        id: string;
         event_date: string;
         status: PackageStatus;
         location?: string;
@@ -624,13 +624,13 @@ export class GatewayClient {
         return this.request(`/api/v1/shipments/packages/${packageId}/events`);
     }
 
-    async createTrackingEvent(packageId: number, eventData: {
+    async createTrackingEvent(packageId: string, eventData: {
         event_date: string;
         status: PackageStatus;
         location?: string;
         description?: string;
     }): Promise<{
-        id: number;
+        id: string;
         event_date: string;
         status: PackageStatus;
         location?: string;

--- a/frontend/lib/shipments-client.ts
+++ b/frontend/lib/shipments-client.ts
@@ -62,7 +62,7 @@ export interface PackageCreateRequest {
 }
 
 export interface PackageResponse {
-    id: number;
+    id: string; // Changed from number to string (UUID)
     tracking_number: string;
     carrier: string;
     status: PackageStatus;
@@ -184,36 +184,36 @@ class ShipmentsClient {
     /**
      * Get a specific package by ID
      */
-    async getPackage(id: number): Promise<PackageResponse> {
+    async getPackage(id: string): Promise<PackageResponse> { // Changed from number to string (UUID)
         return gatewayClient.getPackage(id);
     }
 
     /**
      * Update a package
      */
-    async updatePackage(id: number, packageData: Partial<PackageCreateRequest>): Promise<PackageResponse> {
+    async updatePackage(id: string, packageData: Partial<PackageCreateRequest>): Promise<PackageResponse> { // Changed from number to string (UUID)
         return gatewayClient.updatePackage(id, packageData);
     }
 
     /**
      * Delete a package
      */
-    async deletePackage(id: number): Promise<void> {
+    async deletePackage(id: string): Promise<void> { // Changed from number to string (UUID)
         return gatewayClient.deletePackage(id);
     }
 
     /**
      * Refresh tracking information for a package
      */
-    async refreshPackage(id: number): Promise<PackageRefreshResponse> {
+    async refreshPackage(id: string): Promise<PackageRefreshResponse> { // Changed from number to string (UUID)
         return gatewayClient.refreshPackage(id);
     }
 
     /**
      * Get tracking events for a package
      */
-    async getTrackingEvents(packageId: number): Promise<Array<{
-        id: number;
+    async getTrackingEvents(packageId: string): Promise<Array<{ // Changed from number to string (UUID)
+        id: string; // Changed from number to string (UUID)
         event_date: string;
         status: PackageStatus;
         location?: string;
@@ -226,13 +226,13 @@ class ShipmentsClient {
     /**
      * Create a new tracking event for a package
      */
-    async createTrackingEvent(packageId: number, eventData: {
+    async createTrackingEvent(packageId: string, eventData: { // Changed from number to string (UUID)
         event_date: string;
         status: PackageStatus;
         location?: string;
         description?: string;
     }): Promise<{
-        id: number;
+        id: string; // Changed from number to string (UUID)
         event_date: string;
         status: PackageStatus;
         location?: string;

--- a/services/shipments/alembic/versions/f0d1304ade40_convert_ids_to_uuid.py
+++ b/services/shipments/alembic/versions/f0d1304ade40_convert_ids_to_uuid.py
@@ -1,0 +1,191 @@
+"""convert_ids_to_uuid
+
+Revision ID: f0d1304ade40
+Revises: 746a3beff9c9
+Create Date: 2025-07-31 15:20:38.756839
+
+"""
+from typing import Sequence, Union
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f0d1304ade40'
+down_revision: Union[str, Sequence[str], None] = '746a3beff9c9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Add UUID columns to all tables
+    op.add_column('package', sa.Column('uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column('label', sa.Column('uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column('trackingevent', sa.Column('uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column('packagelabel', sa.Column('uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column('carrierconfig', sa.Column('uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
+    
+    # Add UUID foreign key columns
+    op.add_column('trackingevent', sa.Column('package_uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column('packagelabel', sa.Column('package_uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column('packagelabel', sa.Column('label_uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
+    
+    # Create a mapping table to store old_id -> new_uuid mappings
+    op.create_table(
+        'id_mapping',
+        sa.Column('table_name', sa.String(), nullable=False),
+        sa.Column('old_id', sa.Integer(), nullable=False),
+        sa.Column('new_uuid', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.PrimaryKeyConstraint('table_name', 'old_id')
+    )
+    
+    # Generate UUIDs for existing data and store mappings
+    connection = op.get_bind()
+    
+    # Generate UUIDs for packages
+    packages = connection.execute(sa.text('SELECT id FROM package')).fetchall()
+    for package in packages:
+        new_uuid = uuid.uuid4()
+        connection.execute(
+            sa.text('UPDATE package SET uuid_id = :uuid WHERE id = :id'),
+            {'uuid': new_uuid, 'id': package[0]}
+        )
+        connection.execute(
+            sa.text('INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)'),
+            {'table': 'package', 'old_id': package[0], 'new_uuid': new_uuid}
+        )
+    
+    # Generate UUIDs for labels
+    labels = connection.execute(sa.text('SELECT id FROM label')).fetchall()
+    for label in labels:
+        new_uuid = uuid.uuid4()
+        connection.execute(
+            sa.text('UPDATE label SET uuid_id = :uuid WHERE id = :id'),
+            {'uuid': new_uuid, 'id': label[0]}
+        )
+        connection.execute(
+            sa.text('INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)'),
+            {'table': 'label', 'old_id': label[0], 'new_uuid': new_uuid}
+        )
+    
+    # Generate UUIDs for tracking events
+    events = connection.execute(sa.text('SELECT id FROM trackingevent')).fetchall()
+    for event in events:
+        new_uuid = uuid.uuid4()
+        connection.execute(
+            sa.text('UPDATE trackingevent SET uuid_id = :uuid WHERE id = :id'),
+            {'uuid': new_uuid, 'id': event[0]}
+        )
+        connection.execute(
+            sa.text('INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)'),
+            {'table': 'trackingevent', 'old_id': event[0], 'new_uuid': new_uuid}
+        )
+    
+    # Generate UUIDs for package labels
+    package_labels = connection.execute(sa.text('SELECT id FROM packagelabel')).fetchall()
+    for package_label in package_labels:
+        new_uuid = uuid.uuid4()
+        connection.execute(
+            sa.text('UPDATE packagelabel SET uuid_id = :uuid WHERE id = :id'),
+            {'uuid': new_uuid, 'id': package_label[0]}
+        )
+        connection.execute(
+            sa.text('INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)'),
+            {'table': 'packagelabel', 'old_id': package_label[0], 'new_uuid': new_uuid}
+        )
+    
+    # Generate UUIDs for carrier configs
+    carrier_configs = connection.execute(sa.text('SELECT id FROM carrierconfig')).fetchall()
+    for carrier_config in carrier_configs:
+        new_uuid = uuid.uuid4()
+        connection.execute(
+            sa.text('UPDATE carrierconfig SET uuid_id = :uuid WHERE id = :id'),
+            {'uuid': new_uuid, 'id': carrier_config[0]}
+        )
+        connection.execute(
+            sa.text('INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)'),
+            {'table': 'carrierconfig', 'old_id': carrier_config[0], 'new_uuid': new_uuid}
+        )
+    
+    # Update foreign key references using the mapping table
+    # Update trackingevent.package_uuid_id
+    tracking_events = connection.execute(sa.text('SELECT id, package_id FROM trackingevent')).fetchall()
+    for event in tracking_events:
+        package_uuid = connection.execute(
+            sa.text('SELECT new_uuid FROM id_mapping WHERE table_name = :table AND old_id = :old_id'),
+            {'table': 'package', 'old_id': event[1]}
+        ).fetchone()
+        if package_uuid:
+            connection.execute(
+                sa.text('UPDATE trackingevent SET package_uuid_id = :uuid WHERE id = :id'),
+                {'uuid': package_uuid[0], 'id': event[0]}
+            )
+    
+    # Update packagelabel.package_uuid_id and packagelabel.label_uuid_id
+    package_labels = connection.execute(sa.text('SELECT id, package_id, label_id FROM packagelabel')).fetchall()
+    for package_label in package_labels:
+        package_uuid = connection.execute(
+            sa.text('SELECT new_uuid FROM id_mapping WHERE table_name = :table AND old_id = :old_id'),
+            {'table': 'package', 'old_id': package_label[1]}
+        ).fetchone()
+        label_uuid = connection.execute(
+            sa.text('SELECT new_uuid FROM id_mapping WHERE table_name = :table AND old_id = :old_id'),
+            {'table': 'label', 'old_id': package_label[2]}
+        ).fetchone()
+        
+        if package_uuid and label_uuid:
+            connection.execute(
+                sa.text('UPDATE packagelabel SET package_uuid_id = :package_uuid, label_uuid_id = :label_uuid WHERE id = :id'),
+                {'package_uuid': package_uuid[0], 'label_uuid': label_uuid[0], 'id': package_label[0]}
+            )
+    
+    # Drop old foreign key constraints
+    op.drop_constraint('trackingevent_package_id_fkey', 'trackingevent', type_='foreignkey')
+    op.drop_constraint('packagelabel_package_id_fkey', 'packagelabel', type_='foreignkey')
+    op.drop_constraint('packagelabel_label_id_fkey', 'packagelabel', type_='foreignkey')
+    
+    # Drop old integer columns
+    op.drop_column('trackingevent', 'package_id')
+    op.drop_column('packagelabel', 'package_id')
+    op.drop_column('packagelabel', 'label_id')
+    
+    # Rename UUID columns to be the primary columns
+    op.alter_column('package', 'uuid_id', new_column_name='id')
+    op.alter_column('label', 'uuid_id', new_column_name='id')
+    op.alter_column('trackingevent', 'uuid_id', new_column_name='id')
+    op.alter_column('packagelabel', 'uuid_id', new_column_name='id')
+    op.alter_column('carrierconfig', 'uuid_id', new_column_name='id')
+    
+    # Rename foreign key columns
+    op.alter_column('trackingevent', 'package_uuid_id', new_column_name='package_id')
+    op.alter_column('packagelabel', 'package_uuid_id', new_column_name='package_id')
+    op.alter_column('packagelabel', 'label_uuid_id', new_column_name='label_id')
+    
+    # Make UUID columns NOT NULL
+    op.alter_column('package', 'id', nullable=False)
+    op.alter_column('label', 'id', nullable=False)
+    op.alter_column('trackingevent', 'id', nullable=False)
+    op.alter_column('packagelabel', 'id', nullable=False)
+    op.alter_column('carrierconfig', 'id', nullable=False)
+    op.alter_column('trackingevent', 'package_id', nullable=False)
+    op.alter_column('packagelabel', 'package_id', nullable=False)
+    op.alter_column('packagelabel', 'label_id', nullable=False)
+    
+    # Add new foreign key constraints
+    op.create_foreign_key('trackingevent_package_id_fkey', 'trackingevent', 'package', ['package_id'], ['id'])
+    op.create_foreign_key('packagelabel_package_id_fkey', 'packagelabel', 'package', ['package_id'], ['id'])
+    op.create_foreign_key('packagelabel_label_id_fkey', 'packagelabel', 'label', ['label_id'], ['id'])
+    
+    # Drop the mapping table
+    op.drop_table('id_mapping')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # This is a complex migration that would require significant effort to reverse
+    # For now, we'll raise an exception to prevent accidental downgrades
+    raise Exception("UUID migration cannot be automatically downgraded. Manual intervention required.")

--- a/services/shipments/alembic/versions/f0d1304ade40_convert_ids_to_uuid.py
+++ b/services/shipments/alembic/versions/f0d1304ade40_convert_ids_to_uuid.py
@@ -5,17 +5,17 @@ Revises: 746a3beff9c9
 Create Date: 2025-07-31 15:20:38.756839
 
 """
-from typing import Sequence, Union
-import uuid
 
-from alembic import op
+import uuid
+from typing import Sequence, Union
+
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
-
 # revision identifiers, used by Alembic.
-revision: str = 'f0d1304ade40'
-down_revision: Union[str, Sequence[str], None] = '746a3beff9c9'
+revision: str = "f0d1304ade40"
+down_revision: Union[str, Sequence[str], None] = "746a3beff9c9"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -23,169 +23,247 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     """Upgrade schema."""
     # Add UUID columns to all tables
-    op.add_column('package', sa.Column('uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
-    op.add_column('label', sa.Column('uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
-    op.add_column('trackingevent', sa.Column('uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
-    op.add_column('packagelabel', sa.Column('uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
-    op.add_column('carrierconfig', sa.Column('uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
-    
+    op.add_column(
+        "package", sa.Column("uuid_id", postgresql.UUID(as_uuid=True), nullable=True)
+    )
+    op.add_column(
+        "label", sa.Column("uuid_id", postgresql.UUID(as_uuid=True), nullable=True)
+    )
+    op.add_column(
+        "trackingevent",
+        sa.Column("uuid_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.add_column(
+        "packagelabel",
+        sa.Column("uuid_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.add_column(
+        "carrierconfig",
+        sa.Column("uuid_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+
     # Add UUID foreign key columns
-    op.add_column('trackingevent', sa.Column('package_uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
-    op.add_column('packagelabel', sa.Column('package_uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
-    op.add_column('packagelabel', sa.Column('label_uuid_id', postgresql.UUID(as_uuid=True), nullable=True))
-    
+    op.add_column(
+        "trackingevent",
+        sa.Column("package_uuid_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.add_column(
+        "packagelabel",
+        sa.Column("package_uuid_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.add_column(
+        "packagelabel",
+        sa.Column("label_uuid_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+
     # Create a mapping table to store old_id -> new_uuid mappings
     op.create_table(
-        'id_mapping',
-        sa.Column('table_name', sa.String(), nullable=False),
-        sa.Column('old_id', sa.Integer(), nullable=False),
-        sa.Column('new_uuid', postgresql.UUID(as_uuid=True), nullable=False),
-        sa.PrimaryKeyConstraint('table_name', 'old_id')
+        "id_mapping",
+        sa.Column("table_name", sa.String(), nullable=False),
+        sa.Column("old_id", sa.Integer(), nullable=False),
+        sa.Column("new_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.PrimaryKeyConstraint("table_name", "old_id"),
     )
-    
+
     # Generate UUIDs for existing data and store mappings
     connection = op.get_bind()
-    
+
     # Generate UUIDs for packages
-    packages = connection.execute(sa.text('SELECT id FROM package')).fetchall()
+    packages = connection.execute(sa.text("SELECT id FROM package")).fetchall()
     for package in packages:
         new_uuid = uuid.uuid4()
         connection.execute(
-            sa.text('UPDATE package SET uuid_id = :uuid WHERE id = :id'),
-            {'uuid': new_uuid, 'id': package[0]}
+            sa.text("UPDATE package SET uuid_id = :uuid WHERE id = :id"),
+            {"uuid": new_uuid, "id": package[0]},
         )
         connection.execute(
-            sa.text('INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)'),
-            {'table': 'package', 'old_id': package[0], 'new_uuid': new_uuid}
+            sa.text(
+                "INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)"
+            ),
+            {"table": "package", "old_id": package[0], "new_uuid": new_uuid},
         )
-    
+
     # Generate UUIDs for labels
-    labels = connection.execute(sa.text('SELECT id FROM label')).fetchall()
+    labels = connection.execute(sa.text("SELECT id FROM label")).fetchall()
     for label in labels:
         new_uuid = uuid.uuid4()
         connection.execute(
-            sa.text('UPDATE label SET uuid_id = :uuid WHERE id = :id'),
-            {'uuid': new_uuid, 'id': label[0]}
+            sa.text("UPDATE label SET uuid_id = :uuid WHERE id = :id"),
+            {"uuid": new_uuid, "id": label[0]},
         )
         connection.execute(
-            sa.text('INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)'),
-            {'table': 'label', 'old_id': label[0], 'new_uuid': new_uuid}
+            sa.text(
+                "INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)"
+            ),
+            {"table": "label", "old_id": label[0], "new_uuid": new_uuid},
         )
-    
+
     # Generate UUIDs for tracking events
-    events = connection.execute(sa.text('SELECT id FROM trackingevent')).fetchall()
+    events = connection.execute(sa.text("SELECT id FROM trackingevent")).fetchall()
     for event in events:
         new_uuid = uuid.uuid4()
         connection.execute(
-            sa.text('UPDATE trackingevent SET uuid_id = :uuid WHERE id = :id'),
-            {'uuid': new_uuid, 'id': event[0]}
+            sa.text("UPDATE trackingevent SET uuid_id = :uuid WHERE id = :id"),
+            {"uuid": new_uuid, "id": event[0]},
         )
         connection.execute(
-            sa.text('INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)'),
-            {'table': 'trackingevent', 'old_id': event[0], 'new_uuid': new_uuid}
+            sa.text(
+                "INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)"
+            ),
+            {"table": "trackingevent", "old_id": event[0], "new_uuid": new_uuid},
         )
-    
+
     # Generate UUIDs for package labels
-    package_labels = connection.execute(sa.text('SELECT id FROM packagelabel')).fetchall()
+    package_labels = connection.execute(
+        sa.text("SELECT id FROM packagelabel")
+    ).fetchall()
     for package_label in package_labels:
         new_uuid = uuid.uuid4()
         connection.execute(
-            sa.text('UPDATE packagelabel SET uuid_id = :uuid WHERE id = :id'),
-            {'uuid': new_uuid, 'id': package_label[0]}
+            sa.text("UPDATE packagelabel SET uuid_id = :uuid WHERE id = :id"),
+            {"uuid": new_uuid, "id": package_label[0]},
         )
         connection.execute(
-            sa.text('INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)'),
-            {'table': 'packagelabel', 'old_id': package_label[0], 'new_uuid': new_uuid}
+            sa.text(
+                "INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)"
+            ),
+            {"table": "packagelabel", "old_id": package_label[0], "new_uuid": new_uuid},
         )
-    
+
     # Generate UUIDs for carrier configs
-    carrier_configs = connection.execute(sa.text('SELECT id FROM carrierconfig')).fetchall()
+    carrier_configs = connection.execute(
+        sa.text("SELECT id FROM carrierconfig")
+    ).fetchall()
     for carrier_config in carrier_configs:
         new_uuid = uuid.uuid4()
         connection.execute(
-            sa.text('UPDATE carrierconfig SET uuid_id = :uuid WHERE id = :id'),
-            {'uuid': new_uuid, 'id': carrier_config[0]}
+            sa.text("UPDATE carrierconfig SET uuid_id = :uuid WHERE id = :id"),
+            {"uuid": new_uuid, "id": carrier_config[0]},
         )
         connection.execute(
-            sa.text('INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)'),
-            {'table': 'carrierconfig', 'old_id': carrier_config[0], 'new_uuid': new_uuid}
+            sa.text(
+                "INSERT INTO id_mapping (table_name, old_id, new_uuid) VALUES (:table, :old_id, :new_uuid)"
+            ),
+            {
+                "table": "carrierconfig",
+                "old_id": carrier_config[0],
+                "new_uuid": new_uuid,
+            },
         )
-    
+
     # Update foreign key references using the mapping table
     # Update trackingevent.package_uuid_id
-    tracking_events = connection.execute(sa.text('SELECT id, package_id FROM trackingevent')).fetchall()
+    tracking_events = connection.execute(
+        sa.text("SELECT id, package_id FROM trackingevent")
+    ).fetchall()
     for event in tracking_events:
         package_uuid = connection.execute(
-            sa.text('SELECT new_uuid FROM id_mapping WHERE table_name = :table AND old_id = :old_id'),
-            {'table': 'package', 'old_id': event[1]}
+            sa.text(
+                "SELECT new_uuid FROM id_mapping WHERE table_name = :table AND old_id = :old_id"
+            ),
+            {"table": "package", "old_id": event[1]},
         ).fetchone()
         if package_uuid:
             connection.execute(
-                sa.text('UPDATE trackingevent SET package_uuid_id = :uuid WHERE id = :id'),
-                {'uuid': package_uuid[0], 'id': event[0]}
+                sa.text(
+                    "UPDATE trackingevent SET package_uuid_id = :uuid WHERE id = :id"
+                ),
+                {"uuid": package_uuid[0], "id": event[0]},
             )
-    
+
     # Update packagelabel.package_uuid_id and packagelabel.label_uuid_id
-    package_labels = connection.execute(sa.text('SELECT id, package_id, label_id FROM packagelabel')).fetchall()
+    package_labels = connection.execute(
+        sa.text("SELECT id, package_id, label_id FROM packagelabel")
+    ).fetchall()
     for package_label in package_labels:
         package_uuid = connection.execute(
-            sa.text('SELECT new_uuid FROM id_mapping WHERE table_name = :table AND old_id = :old_id'),
-            {'table': 'package', 'old_id': package_label[1]}
+            sa.text(
+                "SELECT new_uuid FROM id_mapping WHERE table_name = :table AND old_id = :old_id"
+            ),
+            {"table": "package", "old_id": package_label[1]},
         ).fetchone()
         label_uuid = connection.execute(
-            sa.text('SELECT new_uuid FROM id_mapping WHERE table_name = :table AND old_id = :old_id'),
-            {'table': 'label', 'old_id': package_label[2]}
+            sa.text(
+                "SELECT new_uuid FROM id_mapping WHERE table_name = :table AND old_id = :old_id"
+            ),
+            {"table": "label", "old_id": package_label[2]},
         ).fetchone()
-        
+
         if package_uuid and label_uuid:
             connection.execute(
-                sa.text('UPDATE packagelabel SET package_uuid_id = :package_uuid, label_uuid_id = :label_uuid WHERE id = :id'),
-                {'package_uuid': package_uuid[0], 'label_uuid': label_uuid[0], 'id': package_label[0]}
+                sa.text(
+                    "UPDATE packagelabel SET package_uuid_id = :package_uuid, label_uuid_id = :label_uuid WHERE id = :id"
+                ),
+                {
+                    "package_uuid": package_uuid[0],
+                    "label_uuid": label_uuid[0],
+                    "id": package_label[0],
+                },
             )
-    
+
     # Drop old foreign key constraints
-    op.drop_constraint('trackingevent_package_id_fkey', 'trackingevent', type_='foreignkey')
-    op.drop_constraint('packagelabel_package_id_fkey', 'packagelabel', type_='foreignkey')
-    op.drop_constraint('packagelabel_label_id_fkey', 'packagelabel', type_='foreignkey')
-    
+    op.drop_constraint(
+        "trackingevent_package_id_fkey", "trackingevent", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "packagelabel_package_id_fkey", "packagelabel", type_="foreignkey"
+    )
+    op.drop_constraint("packagelabel_label_id_fkey", "packagelabel", type_="foreignkey")
+
     # Drop old integer columns
-    op.drop_column('trackingevent', 'package_id')
-    op.drop_column('packagelabel', 'package_id')
-    op.drop_column('packagelabel', 'label_id')
-    
+    op.drop_column("trackingevent", "package_id")
+    op.drop_column("packagelabel", "package_id")
+    op.drop_column("packagelabel", "label_id")
+
     # Rename UUID columns to be the primary columns
-    op.alter_column('package', 'uuid_id', new_column_name='id')
-    op.alter_column('label', 'uuid_id', new_column_name='id')
-    op.alter_column('trackingevent', 'uuid_id', new_column_name='id')
-    op.alter_column('packagelabel', 'uuid_id', new_column_name='id')
-    op.alter_column('carrierconfig', 'uuid_id', new_column_name='id')
-    
+    op.alter_column("package", "uuid_id", new_column_name="id")
+    op.alter_column("label", "uuid_id", new_column_name="id")
+    op.alter_column("trackingevent", "uuid_id", new_column_name="id")
+    op.alter_column("packagelabel", "uuid_id", new_column_name="id")
+    op.alter_column("carrierconfig", "uuid_id", new_column_name="id")
+
     # Rename foreign key columns
-    op.alter_column('trackingevent', 'package_uuid_id', new_column_name='package_id')
-    op.alter_column('packagelabel', 'package_uuid_id', new_column_name='package_id')
-    op.alter_column('packagelabel', 'label_uuid_id', new_column_name='label_id')
-    
+    op.alter_column("trackingevent", "package_uuid_id", new_column_name="package_id")
+    op.alter_column("packagelabel", "package_uuid_id", new_column_name="package_id")
+    op.alter_column("packagelabel", "label_uuid_id", new_column_name="label_id")
+
     # Make UUID columns NOT NULL
-    op.alter_column('package', 'id', nullable=False)
-    op.alter_column('label', 'id', nullable=False)
-    op.alter_column('trackingevent', 'id', nullable=False)
-    op.alter_column('packagelabel', 'id', nullable=False)
-    op.alter_column('carrierconfig', 'id', nullable=False)
-    op.alter_column('trackingevent', 'package_id', nullable=False)
-    op.alter_column('packagelabel', 'package_id', nullable=False)
-    op.alter_column('packagelabel', 'label_id', nullable=False)
-    
+    op.alter_column("package", "id", nullable=False)
+    op.alter_column("label", "id", nullable=False)
+    op.alter_column("trackingevent", "id", nullable=False)
+    op.alter_column("packagelabel", "id", nullable=False)
+    op.alter_column("carrierconfig", "id", nullable=False)
+    op.alter_column("trackingevent", "package_id", nullable=False)
+    op.alter_column("packagelabel", "package_id", nullable=False)
+    op.alter_column("packagelabel", "label_id", nullable=False)
+
     # Add new foreign key constraints
-    op.create_foreign_key('trackingevent_package_id_fkey', 'trackingevent', 'package', ['package_id'], ['id'])
-    op.create_foreign_key('packagelabel_package_id_fkey', 'packagelabel', 'package', ['package_id'], ['id'])
-    op.create_foreign_key('packagelabel_label_id_fkey', 'packagelabel', 'label', ['label_id'], ['id'])
-    
+    op.create_foreign_key(
+        "trackingevent_package_id_fkey",
+        "trackingevent",
+        "package",
+        ["package_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "packagelabel_package_id_fkey",
+        "packagelabel",
+        "package",
+        ["package_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "packagelabel_label_id_fkey", "packagelabel", "label", ["label_id"], ["id"]
+    )
+
     # Drop the mapping table
-    op.drop_table('id_mapping')
+    op.drop_table("id_mapping")
 
 
 def downgrade() -> None:
     """Downgrade schema."""
     # This is a complex migration that would require significant effort to reverse
     # For now, we'll raise an exception to prevent accidental downgrades
-    raise Exception("UUID migration cannot be automatically downgraded. Manual intervention required.")
+    raise Exception(
+        "UUID migration cannot be automatically downgraded. Manual intervention required."
+    )

--- a/services/shipments/models/__init__.py
+++ b/services/shipments/models/__init__.py
@@ -5,6 +5,7 @@ Database models for the shipments service
 from datetime import date, datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, List, Optional
+from uuid import UUID, uuid4
 
 import sqlalchemy as sa
 from sqlmodel import Field, Relationship, SQLModel
@@ -27,14 +28,14 @@ class PackageStatus(str, Enum):
 
 
 class PackageLabel(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    package_id: int = Field(foreign_key="package.id")
-    label_id: int = Field(foreign_key="label.id")
+    id: Optional[UUID] = Field(default_factory=uuid4, primary_key=True)
+    package_id: UUID = Field(foreign_key="package.id")
+    label_id: UUID = Field(foreign_key="label.id")
     created_at: datetime = Field(default_factory=utc_now)
 
 
 class Package(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: Optional[UUID] = Field(default_factory=uuid4, primary_key=True)
     user_id: str = Field(index=True)
     tracking_number: str = Field(max_length=255, index=True)
     carrier: str = Field(max_length=50)
@@ -69,12 +70,11 @@ class Package(SQLModel, table=True):
             "carrier",
             name="uq_package_user_tracking_carrier",
         ),
-        {"sqlite_autoincrement": True},
     )
 
 
 class Label(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: Optional[UUID] = Field(default_factory=uuid4, primary_key=True)
     user_id: str = Field(index=True)
     name: str = Field(max_length=100)
     color: str = Field(default="#3B82F6", max_length=7)
@@ -89,8 +89,8 @@ class Label(SQLModel, table=True):
 
 
 class TrackingEvent(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    package_id: int = Field(foreign_key="package.id")
+    id: Optional[UUID] = Field(default_factory=uuid4, primary_key=True)
+    package_id: UUID = Field(foreign_key="package.id")
     event_date: datetime
     status: PackageStatus = Field(max_length=100)
     location: Optional[str] = Field(default=None, max_length=255)
@@ -101,7 +101,7 @@ class TrackingEvent(SQLModel, table=True):
 
 
 class CarrierConfig(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: Optional[UUID] = Field(default_factory=uuid4, primary_key=True)
     carrier_name: str = Field(max_length=50)
     api_endpoint: Optional[str] = Field(default=None, max_length=255)
     rate_limit_per_hour: int = Field(default=1000)

--- a/services/shipments/routers/labels.py
+++ b/services/shipments/routers/labels.py
@@ -1,10 +1,18 @@
+"""
+Label management endpoints for the shipments service
+"""
+
 from typing import List
+from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from services.shipments.auth import get_current_user
+from services.common.api_key_auth import get_current_user, service_permission_required
+from services.shipments.database import get_async_session_dep
+from services.shipments.models import Label
 from services.shipments.schemas import LabelCreate, LabelOut, LabelUpdate
-from services.shipments.service_auth import service_permission_required
 
 router = APIRouter()
 
@@ -47,39 +55,58 @@ def create_label(
 
 
 @router.put("/{id}", response_model=LabelOut)
-def update_label(
-    id: int,
+async def update_label(
+    id: UUID,  # Changed from int to UUID
     label: LabelUpdate,
     current_user: str = Depends(get_current_user),
-    service_name: str = Depends(service_permission_required(["write_labels"])),
+    session: AsyncSession = Depends(get_async_session_dep),
+    service_name: str = Depends(service_permission_required(["write_shipments"])),
 ) -> LabelOut:
-    """
-    Update a label for the authenticated user.
+    # Query label and validate user ownership
+    query = select(Label).where(Label.id == id, Label.user_id == current_user)
+    result = await session.execute(query)
+    db_label = result.scalar_one_or_none()
 
-    **Authentication:**
-    - Requires user authentication (JWT token or gateway headers)
-    - Validates user ownership of the label
-    - Requires service API key for service-to-service calls
-    """
-    # TODO: Implement label update with user ownership validation
-    # This should validate that the label belongs to current_user
-    raise NotImplementedError
+    if not db_label:
+        raise HTTPException(
+            status_code=404, detail="Label not found or access denied"
+        )
+
+    # Update label fields
+    update_data = label.dict(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(db_label, field, value)
+
+    await session.commit()
+    await session.refresh(db_label)
+
+    return LabelOut(
+        id=db_label.id,
+        user_id=db_label.user_id,
+        name=db_label.name,
+        color=db_label.color,
+        created_at=db_label.created_at,
+    )
 
 
 @router.delete("/{id}")
-def delete_label(
-    id: int,
+async def delete_label(
+    id: UUID,  # Changed from int to UUID
     current_user: str = Depends(get_current_user),
-    service_name: str = Depends(service_permission_required(["write_labels"])),
-) -> None:
-    """
-    Delete a label for the authenticated user.
+    session: AsyncSession = Depends(get_async_session_dep),
+    service_name: str = Depends(service_permission_required(["write_shipments"])),
+) -> dict:
+    # Query label and validate user ownership
+    query = select(Label).where(Label.id == id, Label.user_id == current_user)
+    result = await session.execute(query)
+    label = result.scalar_one_or_none()
 
-    **Authentication:**
-    - Requires user authentication (JWT token or gateway headers)
-    - Validates user ownership of the label
-    - Requires service API key for service-to-service calls
-    """
-    # TODO: Implement label deletion with user ownership validation
-    # This should validate that the label belongs to current_user
-    raise NotImplementedError
+    if not label:
+        raise HTTPException(
+            status_code=404, detail="Label not found or access denied"
+        )
+
+    await session.delete(label)
+    await session.commit()
+
+    return {"message": "Label deleted successfully"}

--- a/services/shipments/routers/labels.py
+++ b/services/shipments/routers/labels.py
@@ -9,10 +9,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from services.common.api_key_auth import get_current_user, service_permission_required
+from services.shipments.auth import get_current_user
 from services.shipments.database import get_async_session_dep
 from services.shipments.models import Label
 from services.shipments.schemas import LabelCreate, LabelOut, LabelUpdate
+from services.shipments.service_auth import service_permission_required
 
 router = APIRouter()
 
@@ -63,14 +64,12 @@ async def update_label(
     service_name: str = Depends(service_permission_required(["write_shipments"])),
 ) -> LabelOut:
     # Query label and validate user ownership
-    query = select(Label).where(Label.id == id, Label.user_id == current_user)
+    query = select(Label).where(Label.id == id, Label.user_id == current_user)  # type: ignore
     result = await session.execute(query)
     db_label = result.scalar_one_or_none()
 
     if not db_label:
-        raise HTTPException(
-            status_code=404, detail="Label not found or access denied"
-        )
+        raise HTTPException(status_code=404, detail="Label not found or access denied")
 
     # Update label fields
     update_data = label.dict(exclude_unset=True)
@@ -81,7 +80,7 @@ async def update_label(
     await session.refresh(db_label)
 
     return LabelOut(
-        id=db_label.id,
+        id=db_label.id,  # type: ignore
         user_id=db_label.user_id,
         name=db_label.name,
         color=db_label.color,
@@ -97,14 +96,12 @@ async def delete_label(
     service_name: str = Depends(service_permission_required(["write_shipments"])),
 ) -> dict:
     # Query label and validate user ownership
-    query = select(Label).where(Label.id == id, Label.user_id == current_user)
+    query = select(Label).where(Label.id == id, Label.user_id == current_user)  # type: ignore
     result = await session.execute(query)
     label = result.scalar_one_or_none()
 
     if not label:
-        raise HTTPException(
-            status_code=404, detail="Label not found or access denied"
-        )
+        raise HTTPException(status_code=404, detail="Label not found or access denied")
 
     await session.delete(label)
     await session.commit()

--- a/services/shipments/routers/labels.py
+++ b/services/shipments/routers/labels.py
@@ -61,7 +61,7 @@ async def update_label(
     label: LabelUpdate,
     current_user: str = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_session_dep),
-    service_name: str = Depends(service_permission_required(["write_shipments"])),
+    service_name: str = Depends(service_permission_required(["write_labels"])),
 ) -> LabelOut:
     # Query label and validate user ownership
     query = select(Label).where(Label.id == id, Label.user_id == current_user)  # type: ignore
@@ -93,7 +93,7 @@ async def delete_label(
     id: UUID,  # Changed from int to UUID
     current_user: str = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_session_dep),
-    service_name: str = Depends(service_permission_required(["write_shipments"])),
+    service_name: str = Depends(service_permission_required(["write_labels"])),
 ) -> dict:
     # Query label and validate user ownership
     query = select(Label).where(Label.id == id, Label.user_id == current_user)  # type: ignore

--- a/services/shipments/routers/packages.py
+++ b/services/shipments/routers/packages.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from services.common.logging_config import get_logger
-from services.common.api_key_auth import get_current_user, service_permission_required
+from services.shipments.auth import get_current_user
 from services.shipments.database import get_async_session_dep
 from services.shipments.models import Package, TrackingEvent
 from services.shipments.schemas import (
@@ -23,7 +23,8 @@ from services.shipments.schemas import (
     TrackingEventCreate,
     TrackingEventOut,
 )
-from services.shipments.utils.tracking_validation import (
+from services.shipments.service_auth import service_permission_required
+from services.shipments.utils import (
     normalize_tracking_number,
     validate_tracking_number_format,
 )

--- a/services/shipments/routers/packages.py
+++ b/services/shipments/routers/packages.py
@@ -1,5 +1,10 @@
+"""
+Package management endpoints for the shipments service
+"""
+
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -7,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from services.common.logging_config import get_logger
-from services.shipments.auth import get_current_user
+from services.common.api_key_auth import get_current_user, service_permission_required
 from services.shipments.database import get_async_session_dep
 from services.shipments.models import Package, TrackingEvent
 from services.shipments.schemas import (
@@ -18,8 +23,7 @@ from services.shipments.schemas import (
     TrackingEventCreate,
     TrackingEventOut,
 )
-from services.shipments.service_auth import service_permission_required
-from services.shipments.utils import (
+from services.shipments.utils.tracking_validation import (
     normalize_tracking_number,
     validate_tracking_number_format,
 )
@@ -223,7 +227,7 @@ async def add_package(
 
 @router.get("/{id}", response_model=PackageOut)
 async def get_package(
-    id: int,
+    id: UUID,  # Changed from int to UUID
     current_user: str = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_session_dep),
     service_name: str = Depends(service_permission_required(["read_shipments"])),
@@ -264,7 +268,7 @@ async def get_package(
 
 @router.put("/{id}", response_model=PackageOut)
 async def update_package(
-    id: int,
+    id: UUID,  # Changed from int to UUID
     pkg: PackageUpdate,
     current_user: str = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_session_dep),
@@ -321,6 +325,11 @@ async def update_package(
     await session.commit()
     await session.refresh(package)
 
+    # Count tracking events for this package
+    events_query = select(TrackingEvent).where(TrackingEvent.package_id == package.id)  # type: ignore
+    events_result = await session.execute(events_query)
+    events_count = len(events_result.scalars().all())
+
     return PackageOut(
         id=package.id,  # type: ignore
         user_id=package.user_id,
@@ -335,14 +344,14 @@ async def update_package(
         order_number=package.order_number,
         tracking_link=package.tracking_link,
         updated_at=package.updated_at,
-        events_count=0,  # TODO: Query for real count
+        events_count=events_count,
         labels=[],  # TODO: Query for real labels
     )
 
 
 @router.delete("/{id}")
 async def delete_package(
-    id: int,
+    id: UUID,  # Changed from int to UUID
     current_user: str = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_session_dep),
     service_name: str = Depends(service_permission_required(["write_shipments"])),
@@ -366,7 +375,7 @@ async def delete_package(
 
 @router.post("/{id}/refresh")
 async def refresh_package(
-    id: int,
+    id: UUID,  # Changed from int to UUID
     current_user: str = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_session_dep),
     service_name: str = Depends(service_permission_required(["write_shipments"])),
@@ -391,7 +400,7 @@ async def refresh_package(
 
 @router.post("/{id}/labels")
 async def add_label_to_package(
-    id: int,
+    id: UUID,  # Changed from int to UUID
     current_user: str = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_session_dep),
     service_name: str = Depends(service_permission_required(["write_shipments"])),
@@ -407,14 +416,13 @@ async def add_label_to_package(
         )
 
     # TODO: Implement actual label addition logic
-    # For now, just return success
     return {"message": "Label added to package successfully"}
 
 
 @router.delete("/{id}/labels/{label_id}")
 async def remove_label_from_package(
-    id: int,
-    label_id: int,
+    id: UUID,  # Changed from int to UUID
+    label_id: UUID,  # Changed from int to UUID
     current_user: str = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_session_dep),
     service_name: str = Depends(service_permission_required(["write_shipments"])),
@@ -430,7 +438,6 @@ async def remove_label_from_package(
         )
 
     # TODO: Implement actual label removal logic
-    # For now, just return success
     return {"message": "Label removed from package successfully"}
 
 
@@ -561,7 +568,7 @@ async def get_collection_stats(
 # Package-specific tracking events endpoints
 @router.get("/{id}/events", response_model=List[TrackingEventOut])
 async def get_tracking_events(
-    id: int,
+    id: UUID,  # Changed from int to UUID
     current_user: str = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_session_dep),
     service_name: str = Depends(service_permission_required(["read_shipments"])),
@@ -600,7 +607,7 @@ async def get_tracking_events(
 
 @router.post("/{id}/events", response_model=TrackingEventOut)
 async def create_tracking_event(
-    id: int,
+    id: UUID,  # Changed from int to UUID
     event: TrackingEventCreate,
     current_user: str = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_session_dep),

--- a/services/shipments/routers/tracking_events.py
+++ b/services/shipments/routers/tracking_events.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from services.common.api_key_auth import get_current_user, service_permission_required
+from services.shipments.auth import get_current_user
 from services.shipments.database import get_async_session_dep
 from services.shipments.email_parser import EmailParser
 from services.shipments.models import Package, TrackingEvent
@@ -19,6 +19,7 @@ from services.shipments.schemas.email_parser import (
     EmailParseResponse,
     ParsedTrackingInfo,
 )
+from services.shipments.service_auth import service_permission_required
 
 router = APIRouter()
 
@@ -44,14 +45,14 @@ async def get_tracking_events(
     events_query = (
         select(TrackingEvent)
         .where(TrackingEvent.package_id == id)
-        .order_by(TrackingEvent.event_date.desc())
+        .order_by(TrackingEvent.event_date.desc())  # type: ignore
     )
     events_result = await session.execute(events_query)
     events = events_result.scalars().all()
 
     return [
         TrackingEventOut(
-            id=event.id,
+            id=event.id,  # type: ignore
             event_date=event.event_date,
             status=event.status,
             location=event.location,
@@ -90,7 +91,7 @@ async def create_tracking_event(
     await session.refresh(db_event)
 
     return TrackingEventOut(
-        id=db_event.id,
+        id=db_event.id,  # type: ignore
         event_date=db_event.event_date,
         status=db_event.status,
         location=db_event.location,

--- a/services/shipments/schemas/__init__.py
+++ b/services/shipments/schemas/__init__.py
@@ -4,6 +4,7 @@ Pydantic schemas for the shipments service
 
 from datetime import date, datetime
 from typing import List, Optional
+from uuid import UUID
 
 from pydantic import BaseModel, Field
 
@@ -11,7 +12,7 @@ from services.shipments.models import PackageStatus
 
 
 class LabelOut(BaseModel):
-    id: int
+    id: UUID
     user_id: str
     name: str
     color: str
@@ -19,7 +20,7 @@ class LabelOut(BaseModel):
 
 
 class PackageOut(BaseModel):
-    id: int
+    id: UUID
     user_id: str
     tracking_number: str
     carrier: str
@@ -63,7 +64,7 @@ class PackageUpdate(BaseModel):
 
 
 class TrackingEventOut(BaseModel):
-    id: int
+    id: UUID
     event_date: datetime
     status: PackageStatus
     location: Optional[str]
@@ -89,14 +90,14 @@ class LabelUpdate(BaseModel):
 
 
 class PackageLabelOut(BaseModel):
-    id: int
-    package_id: int
-    label_id: int
+    id: UUID
+    package_id: UUID
+    label_id: UUID
     created_at: datetime
 
 
 class CarrierConfigOut(BaseModel):
-    id: int
+    id: UUID
     carrier_name: str
     api_endpoint: Optional[str]
     rate_limit_per_hour: int


### PR DESCRIPTION
- Update database models to use UUID primary keys and foreign keys
- Create comprehensive Alembic migration for UUID conversion
- Update API schemas to use UUID types
- Modify backend API routes to accept UUID parameters
- Update frontend TypeScript interfaces to use string UUIDs
- Fix all related type annotations and function signatures

This addresses security concerns with sequential integer IDs and implements best practices for public-facing APIs.