### PR TITLE
test: unretrieved future exception in the integration service

### DIFF
--- a/services/user/services/integration_service.py
+++ b/services/user/services/integration_service.py
@@ -460,11 +460,13 @@ class IntegrationService:
         # If there was an existing refresh, wait for it
         if existing_future is not None:
             try:
-                result = await asyncio.wait_for(
+                # Wait for the existing future to complete
+                await asyncio.wait_for(
                     existing_future, timeout=get_settings().refresh_timeout_seconds
                 )
-                # If we get here, the future completed successfully
-                return result
+                # If the future completed, get its result. If an exception was stored,
+                # this will raise it, propagating the error to the caller.
+                return existing_future.result()
             except asyncio.TimeoutError:
                 # If the refresh times out, we need to clean up and start a new one
                 self.logger.warning(


### PR DESCRIPTION
- In `test_refresh_deduplication.py`, I adjusted the mock for `scalar_one_or_none` to use a non-terminating generator. This change prevents a `StopIteration` exception, which was leading to a `RuntimeError` within an `asyncio.Future`.
- In `integration_service.py`, I've updated the `refresh_integration_tokens` method to better manage exceptions from waiting tasks. Now, by calling `.result()` on the completed future, any stored exception is re-raised, ensuring it's correctly passed on to the caller.