### PR TITLE
feat(office): optimize MS email thread fetching using api filter

### DIFF
--- a/services/office/api/email.py
+++ b/services/office/api/email.py
@@ -1889,22 +1889,15 @@ async def fetch_single_thread(
                     f"Fetching Microsoft thread {original_thread_id} for user {user_id}"
                 )
                 try:
-                    # Get recent messages and filter client-side by conversationId
+                    filter_query = f"conversationId eq '{original_thread_id}'"
                     messages_response = await microsoft_client.get_messages(
-                        top=200,  # Get more messages to increase chances of finding the thread
+                        filter=filter_query,
                     )
                     messages = messages_response.get("value", [])
 
-                    # Filter messages that belong to this thread
-                    thread_messages = [
-                        msg
-                        for msg in messages
-                        if msg.get("conversationId") == original_thread_id
-                    ]
-
-                    if thread_messages:
+                    if messages:
                         logger.info(
-                            f"Found {len(thread_messages)} messages for thread {original_thread_id}"
+                            f"Found {len(messages)} messages for thread {original_thread_id}"
                         )
 
                         # Get user account info
@@ -1914,7 +1907,7 @@ async def fetch_single_thread(
 
                         return normalize_microsoft_conversation(
                             {"id": original_thread_id},
-                            thread_messages,
+                            messages,
                             account_email,
                             account_name,
                         )

--- a/services/office/api/email.py
+++ b/services/office/api/email.py
@@ -50,6 +50,27 @@ logger = get_logger(__name__)
 # Create router
 router = APIRouter(prefix="/email", tags=["email"])
 
+
+def escape_odata_string_literal(value: str) -> str:
+    """
+    Escape a string literal for use in OData filter expressions.
+
+    OData string literals need to be properly escaped to prevent injection attacks.
+    Single quotes must be escaped by doubling them.
+
+    Args:
+        value: The string value to escape
+
+    Returns:
+        The escaped string safe for use in OData filters
+    """
+    if not isinstance(value, str):
+        raise ValueError("Value must be a string")
+
+    # In OData, single quotes are escaped by doubling them
+    return value.replace("'", "''")
+
+
 # Lazy-initialized API client factory instance
 _api_client_factory = None
 _api_client_factory_lock = asyncio.Lock()
@@ -1265,8 +1286,15 @@ async def fetch_provider_emails(
                 # Build filter for labels (categories in Microsoft)
                 filter_expr = None
                 if labels:
+                    # Properly escape each label to prevent OData injection
+                    escaped_labels = [
+                        escape_odata_string_literal(label) for label in labels
+                    ]
                     category_filter = " or ".join(
-                        [f"categories/any(c:c eq '{label}')" for label in labels]
+                        [
+                            f"categories/any(c:c eq '{escaped_label}')"
+                            for escaped_label in escaped_labels
+                        ]
                     )
                     filter_expr = category_filter
 
@@ -1889,7 +1917,9 @@ async def fetch_single_thread(
                     f"Fetching Microsoft thread {original_thread_id} for user {user_id}"
                 )
                 try:
-                    filter_query = f"conversationId eq '{original_thread_id}'"
+                    # Properly escape the original_thread_id to prevent OData injection
+                    escaped_thread_id = escape_odata_string_literal(original_thread_id)
+                    filter_query = f"conversationId eq '{escaped_thread_id}'"
                     messages_response = await microsoft_client.get_messages(
                         filter=filter_query,
                     )

--- a/services/office/core/clients/microsoft.py
+++ b/services/office/core/clients/microsoft.py
@@ -58,14 +58,17 @@ class MicrosoftAPIClient(BaseAPIClient):
             Dictionary containing messages list and pagination info
         """
         params: Dict[str, Any] = {"$top": top, "$skip": skip}
-        if filter:
-            params["$filter"] = filter
+
         if search:
             params["$search"] = search
-        if order_by:
-            params["$orderby"] = order_by
-        else:
-            params["$orderby"] = "receivedDateTime desc"
+
+        if filter:
+            params["$filter"] = filter
+        else:  # MS does not support order_by with filter
+            if order_by:
+                params["$orderby"] = order_by
+            else:
+                params["$orderby"] = "receivedDateTime desc"
 
         response = await self.get("/me/messages", params=params)
         return response.json()

--- a/services/office/core/clients/microsoft.py
+++ b/services/office/core/clients/microsoft.py
@@ -4,6 +4,26 @@ from services.office.core.clients.base import BaseAPIClient
 from services.office.models import Provider
 
 
+def escape_odata_string_literal(value: str) -> str:
+    """
+    Escape a string literal for use in OData filter expressions.
+
+    OData string literals need to be properly escaped to prevent injection attacks.
+    Single quotes must be escaped by doubling them.
+
+    Args:
+        value: The string value to escape
+
+    Returns:
+        The escaped string safe for use in OData filters
+    """
+    if not isinstance(value, str):
+        raise ValueError("Value must be a string")
+
+    # In OData, single quotes are escaped by doubling them
+    return value.replace("'", "''")
+
+
 class MicrosoftAPIClient(BaseAPIClient):
     """
     Microsoft Graph API client for accessing Outlook, Microsoft Calendar, and OneDrive APIs.
@@ -220,9 +240,11 @@ class MicrosoftAPIClient(BaseAPIClient):
 
             # Add time range filter if only one date specified
             if start_time:
-                params["$filter"] = f"start/dateTime ge '{start_time}'"
+                escaped_start_time = escape_odata_string_literal(start_time)
+                params["$filter"] = f"start/dateTime ge '{escaped_start_time}'"
             elif end_time:
-                params["$filter"] = f"end/dateTime le '{end_time}'"
+                escaped_end_time = escape_odata_string_literal(end_time)
+                params["$filter"] = f"end/dateTime le '{escaped_end_time}'"
 
         response = await self.get(endpoint, params=params)
         return response.json()


### PR DESCRIPTION
- Replace client-side filtering with server-side filter query for conversationId
- Update Microsoft API client to handle filter and order_by parameters correctly
- Improve performance by reducing message retrieval from 200 to filtered results only