### PR TITLE
fix(email): resolve race condition in thread selection state management

### DIFF
--- a/frontend/components/views/email-view.tsx
+++ b/frontend/components/views/email-view.tsx
@@ -373,7 +373,7 @@ const EmailView: React.FC<EmailViewProps> = ({ toolDataLoading = false, activeTo
                     </div>
                 ) : (
                     // Email list (for both two-pane and one-pane modes)
-                    <div className={`flex-1 flex flex-col ${readingPaneMode === 'right' ? 'border-r' : ''}`} style={{ flexShrink: 0, minWidth: 0 }}>
+                    <div className={`flex-1 flex flex-col overflow-y-auto ${readingPaneMode === 'right' ? 'border-r' : ''}`} style={{ flexShrink: 0, minWidth: 0 }}>
                         {loading ? (
                             <div className="p-8 text-center text-muted-foreground">Loading…</div>
                         ) : error ? (


### PR DESCRIPTION
- Remove problematic useEffect that cleared fullThread on selectedThreadId change
- Update handleThreadSelect to clear previous thread data immediately
- Prevent race condition where async fetchFullThread completes after data is cleared
- Ensure proper state transitions when switching between email threads

Fixes issue where right pane showed "No thread data available" instead of email content.