### PR TITLE
fix(meetings): make participant name optional in meeting poll BE

### DIFF
--- a/services/meetings/schemas/__init__.py
+++ b/services/meetings/schemas/__init__.py
@@ -29,7 +29,7 @@ class TimeSlot(TimeSlotBase):
 
 class PollParticipantBase(BaseModel):
     email: EmailStr
-    name: Optional[str]
+    name: Optional[str] = None
 
 
 class PollParticipantCreate(PollParticipantBase):


### PR DESCRIPTION
Make participant name optional in meeting poll schema to prevent backend errors when name is omitted.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ef3ff4d-8a9a-4bf2-b99f-772dbb444c96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ef3ff4d-8a9a-4bf2-b99f-772dbb444c96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

