### PR TITLE
fix: resolve Safari SSL errors on meetings respond endpoint

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -32,10 +32,13 @@ const nextConfig = {
         // Only add upgrade-insecure-requests in production
         if (isProduction) {
             cspDirectives.push("upgrade-insecure-requests");
-            // In production, also add HTTPS version of gateway URL
+            // In production, also add HTTPS version of gateway URL by appending to existing connect-src
             if (gatewayUrl.startsWith('http://')) {
                 const httpsGatewayUrl = gatewayUrl.replace('http://', 'https://');
-                cspDirectives.push(`connect-src 'self' ${gatewayUrl} ${httpsGatewayUrl} https://login.microsoftonline.com https://graph.microsoft.com https://accounts.google.com https://www.googleapis.com`);
+                const connectSrcIndex = cspDirectives.findIndex((directive) => directive.startsWith("connect-src "));
+                if (connectSrcIndex !== -1 && !cspDirectives[connectSrcIndex].includes(httpsGatewayUrl)) {
+                    cspDirectives[connectSrcIndex] = `${cspDirectives[connectSrcIndex]} ${httpsGatewayUrl}`;
+                }
             }
         }
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -12,6 +12,32 @@ const nextConfig = {
     async headers() {
         // Get gateway URL from environment variable
         const gatewayUrl = process.env.NEXT_PUBLIC_GATEWAY_URL || 'http://localhost:3001';
+        const isProduction = process.env.NODE_ENV === 'production';
+
+        // Build CSP directives
+        const cspDirectives = [
+            "default-src 'self'",
+            "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
+            "style-src 'self' 'unsafe-inline'",
+            "img-src 'self' data: https:",
+            "font-src 'self'",
+            `connect-src 'self' ${gatewayUrl} https://login.microsoftonline.com https://graph.microsoft.com https://accounts.google.com https://www.googleapis.com`,
+            "frame-src 'none'",
+            "object-src 'none'",
+            "base-uri 'self'",
+            "form-action 'self'",
+            "frame-ancestors 'none'"
+        ];
+
+        // Only add upgrade-insecure-requests in production
+        if (isProduction) {
+            cspDirectives.push("upgrade-insecure-requests");
+            // In production, also add HTTPS version of gateway URL
+            if (gatewayUrl.startsWith('http://')) {
+                const httpsGatewayUrl = gatewayUrl.replace('http://', 'https://');
+                cspDirectives.push(`connect-src 'self' ${gatewayUrl} ${httpsGatewayUrl} https://login.microsoftonline.com https://graph.microsoft.com https://accounts.google.com https://www.googleapis.com`);
+            }
+        }
 
         return [
             {
@@ -19,20 +45,7 @@ const nextConfig = {
                 headers: [
                     {
                         key: 'Content-Security-Policy',
-                        value: [
-                            "default-src 'self'",
-                            "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
-                            "style-src 'self' 'unsafe-inline'",
-                            "img-src 'self' data: https:",
-                            "font-src 'self'",
-                            `connect-src 'self' ${gatewayUrl} ${gatewayUrl.replace('http://', 'https://')} https://login.microsoftonline.com https://graph.microsoft.com https://accounts.google.com https://www.googleapis.com`,
-                            "frame-src 'none'",
-                            "object-src 'none'",
-                            "base-uri 'self'",
-                            "form-action 'self'",
-                            "frame-ancestors 'none'",
-                            "upgrade-insecure-requests"
-                        ].join('; ')
+                        value: cspDirectives.join('; ')
                     },
                     {
                         key: 'X-Content-Type-Options',


### PR DESCRIPTION
- Remove 'upgrade-insecure-requests' from CSP in development mode
- Conditionally apply HTTPS upgrade only in production environments
- Add missing NEXT_PUBLIC_GATEWAY_URL environment variable
- Add missing gateway environment variables for meetings and shipments services
- Fix Content Security Policy to prevent Safari from forcing HTTPS on localhost

This resolves the "Loading poll..." hang issue where Safari was failing to load JavaScript files due to SSL errors when trying to access HTTP resources over HTTPS connections.