### PR TITLE
Enable click anywhere cursor activation in editor

### DIFF
--- a/frontend/components/draft/editors/calendar-editor.tsx
+++ b/frontend/components/draft/editors/calendar-editor.tsx
@@ -4,6 +4,7 @@ import { useEditor } from '@/hooks/use-editor';
 import { cn } from '@/lib/utils';
 import { EditorContent } from '@tiptap/react';
 import { useEffect, useState } from 'react';
+import type { MouseEvent } from 'react';
 import { EditorToolbar } from '../editor-toolbar';
 
 interface CalendarEditorProps {
@@ -48,13 +49,23 @@ export function CalendarEditor({
     const characterCount = getCharacterCount(content);
     const showErrors = hasInteracted && errors.length > 0;
 
+    const handleContainerMouseDown = (e: MouseEvent<HTMLDivElement>) => {
+        if (!editor || disabled) return;
+        const target = e.target as HTMLElement;
+        const isInsideProseMirror = !!target.closest('.ProseMirror');
+        if (!isInsideProseMirror) {
+            e.preventDefault();
+            editor.commands.focus('end');
+        }
+    };
+
     return (
         <div className={cn('flex flex-col h-full', className)}>
             {/* Toolbar */}
             <EditorToolbar editor={editor} />
 
             {/* Editor Content */}
-            <div className="flex-1 min-h-0 p-4">
+            <div className="flex-1 min-h-0 p-4 cursor-text" onMouseDown={handleContainerMouseDown}>
                 <EditorContent
                     editor={editor}
                     className={cn(

--- a/frontend/components/draft/editors/document-editor.tsx
+++ b/frontend/components/draft/editors/document-editor.tsx
@@ -4,6 +4,7 @@ import { useEditor } from '@/hooks/use-editor';
 import { cn } from '@/lib/utils';
 import { EditorContent } from '@tiptap/react';
 import { useEffect, useState } from 'react';
+import type { MouseEvent } from 'react';
 import { EditorToolbar } from '../editor-toolbar';
 
 interface DocumentEditorProps {
@@ -48,13 +49,23 @@ export function DocumentEditor({
     const characterCount = getCharacterCount(content);
     const showErrors = hasInteracted && errors.length > 0;
 
+    const handleContainerMouseDown = (e: MouseEvent<HTMLDivElement>) => {
+        if (!editor || disabled) return;
+        const target = e.target as HTMLElement;
+        const isInsideProseMirror = !!target.closest('.ProseMirror');
+        if (!isInsideProseMirror) {
+            e.preventDefault();
+            editor.commands.focus('end');
+        }
+    };
+
     return (
         <div className={cn('flex flex-col h-full', className)}>
             {/* Toolbar */}
             <EditorToolbar editor={editor} />
 
             {/* Editor Content */}
-            <div className="flex-1 min-h-0 p-4">
+            <div className="flex-1 min-h-0 p-4 cursor-text" onMouseDown={handleContainerMouseDown}>
                 <EditorContent
                     editor={editor}
                     className={cn(

--- a/frontend/components/draft/editors/email-editor.tsx
+++ b/frontend/components/draft/editors/email-editor.tsx
@@ -4,6 +4,7 @@ import { useEditor } from '@/hooks/use-editor';
 import { cn } from '@/lib/utils';
 import { EditorContent } from '@tiptap/react';
 import { useEffect, useState } from 'react';
+import type { MouseEvent } from 'react';
 import { EditorToolbar } from '../editor-toolbar';
 
 interface EmailEditorProps {
@@ -48,13 +49,23 @@ export function EmailEditor({
     const characterCount = getCharacterCount(content);
     const showErrors = hasInteracted && errors.length > 0;
 
+    const handleContainerMouseDown = (e: MouseEvent<HTMLDivElement>) => {
+        if (!editor || disabled) return;
+        const target = e.target as HTMLElement;
+        const isInsideProseMirror = !!target.closest('.ProseMirror');
+        if (!isInsideProseMirror) {
+            e.preventDefault();
+            editor.commands.focus('end');
+        }
+    };
+
     return (
         <div className={cn('flex flex-col h-full', className)}>
             {/* Toolbar */}
             <EditorToolbar editor={editor} />
 
             {/* Editor Content */}
-            <div className="flex-1 min-h-0 p-4">
+            <div className="flex-1 min-h-0 p-4 cursor-text" onMouseDown={handleContainerMouseDown}>
                 <EditorContent
                     editor={editor}
                     className={cn(


### PR DESCRIPTION
Enable click-to-focus on TipTap editor containers to improve usability by allowing users to activate the cursor anywhere in the text entry box.

---
<a href="https://cursor.com/background-agent?bcId=bc-80f52d0d-2414-41b9-875a-3234ce03994d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80f52d0d-2414-41b9-875a-3234ce03994d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

