### PR TITLE
feat(meetings): Enable drag to select multiple items

### DIFF
--- a/frontend/components/meetings/time-slot-calendar.tsx
+++ b/frontend/components/meetings/time-slot-calendar.tsx
@@ -8,7 +8,7 @@ import { SmartTimeDurationInput } from '@/components/ui/smart-time-duration-inpu
 import { CalendarEvent } from '@/types/office-service';
 import { Check, CheckCheck, Clock, Eye, EyeOff, Pencil, X } from 'lucide-react';
 import { DateTime } from 'luxon';
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useMemo, useRef, useState, useEffect } from 'react';
 
 interface TimeSlotCalendarProps {
     duration: number;
@@ -63,18 +63,20 @@ interface TimeSlotCellProps {
     slot: TimeSlot;
     slotIndex: number;
     isSelected: boolean;
-    onSlotClick: (slot: TimeSlot) => void;
+    onSlotMouseDown?: (slot: TimeSlot, slotIndex: number, isSelected: boolean) => void;
+    onSlotMouseEnter?: (slot: TimeSlot, slotIndex: number) => void;
 }
 
-const TimeSlotCell = memo<TimeSlotCellProps>(({ slot, slotIndex, isSelected, onSlotClick }) => {
+const TimeSlotCell = memo<TimeSlotCellProps>(({ slot, slotIndex, isSelected, onSlotMouseDown, onSlotMouseEnter }) => {
 
     return (
         <button
             key={`${slot.start}-${slot.end}`}
             type="button"
-            onClick={() => onSlotClick(slot)}
+            onMouseDown={(e) => { e.preventDefault(); onSlotMouseDown?.(slot, slotIndex, isSelected); }}
+            onMouseEnter={() => { onSlotMouseEnter?.(slot, slotIndex); }}
             className={`
-                absolute left-0 right-0 h-8 text-xs transition-colors z-10 rounded-sm
+                absolute left-0 right-0 h-8 text-xs transition-colors z-10 rounded-sm select-none
                 ${isSelected
                     ? slot.isConflict
                         ? 'bg-orange-500/50 border border-orange-600 text-orange-800 hover:bg-orange-500/70'
@@ -107,6 +109,87 @@ export function TimeSlotCalendar({
     // Use ref to track current selected slots without dependencies
     const selectedSlotsRef = useRef(selectedTimeSlots);
     selectedSlotsRef.current = selectedTimeSlots;
+
+    // Drag selection state
+    const [isDragging, setIsDragging] = useState(false);
+    const dragInfoRef = useRef<{
+        dateKey: string;
+        startIndex: number;
+        currentIndex: number;
+        mode: 'add' | 'remove';
+        initialSelected: { start: string; end: string }[];
+    } | null>(null);
+
+    const applyDragSelection = useCallback((dateKey: string, startIndex: number, currentIndex: number, mode: 'add' | 'remove') => {
+        const daySlots = slotsByDate[dateKey] || [];
+        const rangeStart = Math.max(0, Math.min(startIndex, currentIndex));
+        const rangeEnd = Math.min(daySlots.length - 1, Math.max(startIndex, currentIndex));
+
+        const currentDragInfo = dragInfoRef.current;
+        const initialSelected = (currentDragInfo?.initialSelected || []).slice();
+
+        const rangeIds = new Set<string>();
+        for (let i = rangeStart; i <= rangeEnd; i++) {
+            const s = daySlots[i];
+            if (!s) continue;
+            rangeIds.add(`${s.start}-${s.end}`);
+        }
+
+        if (mode === 'add') {
+            const existingIds = new Set(initialSelected.map(s => `${s.start}-${s.end}`));
+            const newSelected = initialSelected.slice();
+            for (let i = rangeStart; i <= rangeEnd; i++) {
+                const s = daySlots[i];
+                if (!s) continue;
+                const id = `${s.start}-${s.end}`;
+                if (!existingIds.has(id)) {
+                    newSelected.push({ start: s.start, end: s.end });
+                    existingIds.add(id);
+                }
+            }
+            onTimeSlotsChange(newSelected);
+        } else {
+            // remove
+            const newSelected = initialSelected.filter(s => !rangeIds.has(`${s.start}-${s.end}`));
+            onTimeSlotsChange(newSelected);
+        }
+    }, [onTimeSlotsChange]);
+
+    const handleGlobalMouseUp = useCallback(() => {
+        setIsDragging(false);
+        dragInfoRef.current = null;
+        document.removeEventListener('mouseup', handleGlobalMouseUp);
+    }, []);
+
+    const handleSlotMouseDownFactory = useCallback((dateKey: string) => (slot: TimeSlot, slotIndex: number, isSelected: boolean) => {
+        setIsDragging(true);
+        dragInfoRef.current = {
+            dateKey,
+            startIndex: slotIndex,
+            currentIndex: slotIndex,
+            mode: isSelected ? 'remove' : 'add',
+            initialSelected: selectedTimeSlots.slice()
+        };
+        applyDragSelection(dateKey, slotIndex, slotIndex, isSelected ? 'remove' : 'add');
+        document.addEventListener('mouseup', handleGlobalMouseUp);
+    }, [applyDragSelection, handleGlobalMouseUp, selectedTimeSlots]);
+
+    const handleSlotMouseEnterFactory = useCallback((dateKey: string) => (_slot: TimeSlot, slotIndex: number) => {
+        const info = dragInfoRef.current;
+        if (!isDragging || !info) return;
+        if (info.dateKey !== dateKey) return; // restrict to a single day
+        if (info.currentIndex === slotIndex) return;
+        info.currentIndex = slotIndex;
+        applyDragSelection(info.dateKey, info.startIndex, slotIndex, info.mode);
+    }, [applyDragSelection, isDragging]);
+
+    // Cleanup mouseup listener on unmount just in case
+    useEffect(() => {
+        return () => {
+            document.removeEventListener('mouseup', handleGlobalMouseUp);
+        };
+    }, [handleGlobalMouseUp]);
+
     // Date range selection
     const [dateRangeType, setDateRangeType] = useState<'target' | 'range'>('target');
     const [targetDate, setTargetDate] = useState(() => {
@@ -574,7 +657,8 @@ export function TimeSlotCalendar({
                                                     slot={slot}
                                                     slotIndex={slotIndex}
                                                     isSelected={isSelected}
-                                                    onSlotClick={handleSlotClick}
+                                                    onSlotMouseDown={handleSlotMouseDownFactory(dateKey)}
+                                                    onSlotMouseEnter={handleSlotMouseEnterFactory(dateKey)}
                                                 />
                                             );
                                         })}


### PR DESCRIPTION
Enable click-and-drag selection of multiple time slots in the new meetings calendar.

---
<a href="https://cursor.com/background-agent?bcId=bc-f28bfe07-03cd-4462-8ea4-be4f84926b32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f28bfe07-03cd-4462-8ea4-be4f84926b32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

