### PR TITLE
feat(email): Add meeting poll creation from email

### DIFF
--- a/frontend/components/email/email-thread-card.test.tsx
+++ b/frontend/components/email/email-thread-card.test.tsx
@@ -3,6 +3,11 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import EmailThreadCard from './email-thread-card';
 
+// Mock Next.js navigation
+jest.mock('next/navigation', () => ({
+    useRouter: jest.fn(),
+}));
+
 // Mock hooks used inside the component to avoid network and side effects
 jest.mock('@/hooks/use-shipment-detection', () => ({
     useShipmentDetection: () => ({ trackingNumbers: [] })
@@ -21,6 +26,15 @@ jest.mock('next-auth/react', () => ({
     signOut: jest.fn(),
     SessionProvider: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
+
+const mockRouter = {
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+    prefetch: jest.fn(),
+};
 
 const baseEmail: EmailMessage = {
     id: 'test-id',
@@ -44,6 +58,11 @@ const baseEmail: EmailMessage = {
 };
 
 describe('EmailThreadCard rendering', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (require('next/navigation').useRouter as jest.Mock).mockReturnValue(mockRouter);
+    });
+
     it('renders simple HTML body without toggle', () => {
         const simpleHtml = '<html><body><div>Try it out today!</div></body></html>';
         render(

--- a/frontend/components/email/email-thread-card.test.tsx
+++ b/frontend/components/email/email-thread-card.test.tsx
@@ -2,6 +2,7 @@ import { EmailMessage } from '@/types/office-service';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import EmailThreadCard from './email-thread-card';
+import { useRouter } from 'next/navigation';
 
 // Mock Next.js navigation
 jest.mock('next/navigation', () => ({
@@ -60,7 +61,7 @@ const baseEmail: EmailMessage = {
 describe('EmailThreadCard rendering', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        (require('next/navigation').useRouter as jest.Mock).mockReturnValue(mockRouter);
+        (useRouter as jest.Mock).mockReturnValue(mockRouter);
     });
 
     it('renders simple HTML body without toggle', () => {

--- a/frontend/components/email/email-thread-card.test.tsx
+++ b/frontend/components/email/email-thread-card.test.tsx
@@ -1,8 +1,8 @@
 import { EmailMessage } from '@/types/office-service';
 import { render, screen } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
 import React from 'react';
 import EmailThreadCard from './email-thread-card';
-import { useRouter } from 'next/navigation';
 
 // Mock Next.js navigation
 jest.mock('next/navigation', () => ({

--- a/frontend/components/email/email-thread-card.tsx
+++ b/frontend/components/email/email-thread-card.tsx
@@ -11,6 +11,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import AISummary from './ai-summary';
 import TrackShipmentModal, { PackageFormData } from './track-shipment-modal';
+import { useRouter } from 'next/navigation';
 // inline draft removed; thread-level draft card is handled by parent
 
 // Configure DOMPurify for email content
@@ -314,6 +315,7 @@ const EmailThreadCard: React.FC<EmailThreadCardProps> = ({
     onReplyAll,
     onForward,
 }) => {
+    const router = useRouter();
     const [isModalOpen, setIsModalOpen] = useState(false);
     const shipmentDetection = useShipmentDetection(email);
     const { data: shipmentEvents, hasEvents } = useShipmentEvents(email.id);
@@ -521,13 +523,13 @@ const EmailThreadCard: React.FC<EmailThreadCardProps> = ({
                                                 // Only include recipients (to + cc)
                                                 email.to_addresses.forEach(a => addAddr(a));
                                                 email.cc_addresses.forEach(a => addAddr(a));
-                                                const participantsParam = parts.join(', ');
-                                                const url = new URL(window.location.href);
-                                                url.searchParams.set('tool', 'meetings');
-                                                url.searchParams.set('view', 'new');
-                                                url.searchParams.set('step', '3');
-                                                url.searchParams.set('participants', participantsParam);
-                                                window.history.pushState({ step: 3 }, '', url.toString());
+                                                const params = new URLSearchParams();
+                                                params.set('tool', 'meetings');
+                                                params.set('view', 'new');
+                                                params.set('step', '1');
+                                                if (email.subject) params.set('title', email.subject);
+                                                params.set('participants', parts.join(', '));
+                                                router.replace(`/dashboard?${params.toString()}`);
                                                 // Let meetings tool pick up the new view
                                                 // No explicit context call here to avoid cross-component coupling
                                             } catch (err) {

--- a/frontend/components/email/email-thread.tsx
+++ b/frontend/components/email/email-thread.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { safeParseDate } from '@/lib/utils';
 import { EmailThread as EmailThreadType } from '@/types/office-service';
-import { Archive, Clock, Download, MoreHorizontal, Reply, Star, Trash2 } from 'lucide-react';
+import { Archive, CalendarRange, Clock, Download, MoreHorizontal, Reply, Star, Trash2 } from 'lucide-react';
 import React, { useState } from 'react';
 import EmailThreadCard from './email-thread-card';
 // removed global draft pane wiring for thread-level drafts
@@ -240,6 +240,39 @@ const EmailThread: React.FC<EmailThreadProps> = ({
                                     <DropdownMenuItem onClick={handleDownload}>
                                         <Download className="h-4 w-4 mr-2" />
                                         Download
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem onClick={() => {
+                                        try {
+                                            const latest = thread.messages[thread.messages.length - 1];
+                                            const parts: string[] = [];
+                                            const seenEmails = new Set<string>();
+                                            const addAddr = (addr?: { email?: string; name?: string } | null) => {
+                                                if (!addr || !addr.email) return;
+                                                const emailLower = addr.email.toLowerCase().trim();
+                                                if (seenEmails.has(emailLower)) return;
+                                                seenEmails.add(emailLower);
+                                                const name = (addr.name || '').trim();
+                                                if (name) {
+                                                    parts.push(`${name} <${addr.email}>`);
+                                                } else {
+                                                    parts.push(addr.email);
+                                                }
+                                            };
+                                            latest.to_addresses.forEach(a => addAddr(a));
+                                            latest.cc_addresses.forEach(a => addAddr(a));
+                                            const participantsParam = parts.join(', ');
+                                            const url = new URL(window.location.href);
+                                            url.searchParams.set('tool', 'meetings');
+                                            url.searchParams.set('view', 'new');
+                                            url.searchParams.set('step', '3');
+                                            url.searchParams.set('participants', participantsParam);
+                                            window.history.pushState({ step: 3 }, '', url.toString());
+                                        } catch (err) {
+                                            console.error('Failed to navigate to meeting poll creator:', err);
+                                        }
+                                    }}>
+                                        <CalendarRange className="h-4 w-4 mr-2" />
+                                        Create Meeting Poll
                                     </DropdownMenuItem>
 
                                 </DropdownMenuContent>

--- a/frontend/components/email/email-thread.tsx
+++ b/frontend/components/email/email-thread.tsx
@@ -9,6 +9,7 @@ import EmailThreadCard from './email-thread-card';
 import { getSession } from 'next-auth/react';
 import EmailThreadDraft from './email-thread-draft';
 import { Draft } from '@/types/draft';
+import { useRouter } from 'next/navigation';
 
 interface EmailThreadProps {
     thread: EmailThreadType;
@@ -21,6 +22,7 @@ const EmailThread: React.FC<EmailThreadProps> = ({
     onSelectMessage,
     selectedMessageId
 }) => {
+    const router = useRouter();
     const [isStarred, setIsStarred] = useState(false);
     const [threadDrafts, setThreadDrafts] = useState<Draft[]>([]);
 
@@ -260,13 +262,13 @@ const EmailThread: React.FC<EmailThreadProps> = ({
                                             };
                                             latest.to_addresses.forEach(a => addAddr(a));
                                             latest.cc_addresses.forEach(a => addAddr(a));
-                                            const participantsParam = parts.join(', ');
-                                            const url = new URL(window.location.href);
-                                            url.searchParams.set('tool', 'meetings');
-                                            url.searchParams.set('view', 'new');
-                                            url.searchParams.set('step', '3');
-                                            url.searchParams.set('participants', participantsParam);
-                                            window.history.pushState({ step: 3 }, '', url.toString());
+                                            const params = new URLSearchParams();
+                                            params.set('tool', 'meetings');
+                                            params.set('view', 'new');
+                                            params.set('step', '1');
+                                            if (latest.subject) params.set('title', latest.subject);
+                                            params.set('participants', parts.join(', '));
+                                            router.replace(`/dashboard?${params.toString()}`);
                                         } catch (err) {
                                             console.error('Failed to navigate to meeting poll creator:', err);
                                         }

--- a/frontend/components/meetings/meeting-poll-new.tsx
+++ b/frontend/components/meetings/meeting-poll-new.tsx
@@ -487,9 +487,20 @@ export function MeetingPollNew() {
                 const parsed = parsePeopleFromText(prefill);
                 if (parsed && parsed.length > 0) {
                     addPeople(parsed);
-                    // If participants were prefilled, and we are at step 1, advance to step 3 for convenience
-                    setStep((s) => (s < 3 ? 3 : s));
                 }
+            }
+        } catch {
+            // ignore parse errors
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // Prefill title from URL param if provided
+    useEffect(() => {
+        try {
+            const t = searchParams.get('title');
+            if (t && typeof t === 'string' && t.trim()) {
+                setTitle(t);
             }
         } catch {
             // ignore parse errors

--- a/frontend/components/meetings/meeting-poll-new.tsx
+++ b/frontend/components/meetings/meeting-poll-new.tsx
@@ -480,33 +480,44 @@ export function MeetingPollNew() {
     };
 
     // Prefill participants from URL param if provided (e.g., "Name <email>, another@example.com")
+    const participantsParam = searchParams.get('participants');
     useEffect(() => {
         try {
-            const prefill = searchParams.get('participants');
-            if (prefill && typeof prefill === 'string') {
-                const parsed = parsePeopleFromText(prefill);
+            if (participantsParam && typeof participantsParam === 'string') {
+                const parsed = parsePeopleFromText(participantsParam);
                 if (parsed && parsed.length > 0) {
-                    addPeople(parsed);
+                    setParticipants(parsed.map(person => ({
+                        id: generateTempId(),
+                        email: person.email.trim(),
+                        name: (person.name || "").trim(),
+                    })));
+                } else {
+                    setParticipants([]);
                 }
             }
-        } catch {
-            // ignore parse errors
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    // Prefill title from URL param if provided
-    useEffect(() => {
-        try {
-            const t = searchParams.get('title');
-            if (t && typeof t === 'string' && t.trim()) {
-                setTitle(t);
+            else {
+                setParticipants([]);
             }
         } catch {
             // ignore parse errors
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [participantsParam]);
+
+    // Prefill title from URL param if provided
+    const titleParam = searchParams.get('title');
+    useEffect(() => {
+        try {
+            if (titleParam && typeof titleParam === 'string' && titleParam.trim()) {
+                setTitle(titleParam);
+            } else {
+                setTitle("");
+            }
+        } catch {
+            // ignore parse errors
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [titleParam]);
 
     // Suggestions stub (to be replaced with contacts provider)
     useEffect(() => {

--- a/frontend/components/meetings/meeting-poll-new.tsx
+++ b/frontend/components/meetings/meeting-poll-new.tsx
@@ -479,6 +479,24 @@ export function MeetingPollNew() {
         }
     };
 
+    // Prefill participants from URL param if provided (e.g., "Name <email>, another@example.com")
+    useEffect(() => {
+        try {
+            const prefill = searchParams.get('participants');
+            if (prefill && typeof prefill === 'string') {
+                const parsed = parsePeopleFromText(prefill);
+                if (parsed && parsed.length > 0) {
+                    addPeople(parsed);
+                    // If participants were prefilled, and we are at step 1, advance to step 3 for convenience
+                    setStep((s) => (s < 3 ? 3 : s));
+                }
+            }
+        } catch {
+            // ignore parse errors
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
     // Suggestions stub (to be replaced with contacts provider)
     useEffect(() => {
         if (!personQuery.trim()) {

--- a/frontend/components/meetings/meeting-poll-new.tsx
+++ b/frontend/components/meetings/meeting-poll-new.tsx
@@ -13,12 +13,15 @@ import { CalendarEvent } from "@/types/office-service";
 import { ArrowLeft, LinkIcon, XCircle } from "lucide-react";
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useUserPreferences } from '../../contexts/settings-context';
 import { TimeSlotCalendar } from "./time-slot-calendar";
 
 const getTimeZones = () =>
     Intl.supportedValuesOf ? Intl.supportedValuesOf("timeZone") : ["UTC"];
+
+// Email regex pattern - moved outside component to avoid dependency issues
+const EMAIL_REGEX = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
 
 export function MeetingPollNew() {
     const { setMeetingSubView } = useToolState();
@@ -356,7 +359,7 @@ export function MeetingPollNew() {
     const removeParticipant = (id: string) =>
         setParticipants(prev => prev.filter(p => p.id !== id));
 
-    const generateTempId = (): string => {
+    const generateTempId = useCallback((): string => {
         try {
             // Prefer stable UUID when available
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -368,12 +371,11 @@ export function MeetingPollNew() {
             // ignore
         }
         return `p_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
-    };
+    }, []);
 
     // ---- Step 3 helpers: parsing and adding people ----
-    const EMAIL_REGEX = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
 
-    const parsePeopleFromText = (text: string): Array<{ email: string; name?: string }> => {
+    const parsePeopleFromText = useCallback((text: string): Array<{ email: string; name?: string }> => {
         const results: Array<{ email: string; name?: string }> = [];
         if (!text) return results;
 
@@ -438,7 +440,7 @@ export function MeetingPollNew() {
             deduped.push(r);
         }
         return deduped;
-    };
+    }, []);
 
     const addPeople = (people: Array<{ email: string; name?: string }>) => {
         if (!people || people.length === 0) return;
@@ -481,9 +483,13 @@ export function MeetingPollNew() {
 
     // Prefill participants from URL param if provided (e.g., "Name <email>, another@example.com")
     const participantsParam = searchParams.get('participants');
+    const hasPrefilledParticipants = useRef(false);
     useEffect(() => {
+        // Only prefill on initial mount, not on every URL param change
+        if (hasPrefilledParticipants.current) return;
+
         try {
-            if (participantsParam && typeof participantsParam === 'string') {
+            if (participantsParam && typeof participantsParam === 'string' && participantsParam.trim()) {
                 const parsed = parsePeopleFromText(participantsParam);
                 if (parsed && parsed.length > 0) {
                     setParticipants(parsed.map(person => ({
@@ -491,32 +497,31 @@ export function MeetingPollNew() {
                         email: person.email.trim(),
                         name: (person.name || "").trim(),
                     })));
-                } else {
-                    setParticipants([]);
+                    hasPrefilledParticipants.current = true;
                 }
             }
-            else {
-                setParticipants([]);
-            }
+            // Don't clear participants if param is missing - user might have entered data manually
         } catch {
             // ignore parse errors
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [participantsParam]);
+    }, [participantsParam, parsePeopleFromText, generateTempId]);
 
     // Prefill title from URL param if provided
     const titleParam = searchParams.get('title');
+    const hasPrefilledTitle = useRef(false);
     useEffect(() => {
+        // Only prefill on initial mount, not on every URL param change
+        if (hasPrefilledTitle.current) return;
+
         try {
             if (titleParam && typeof titleParam === 'string' && titleParam.trim()) {
                 setTitle(titleParam);
-            } else {
-                setTitle("");
+                hasPrefilledTitle.current = true;
             }
+            // Don't clear title if param is missing - user might have entered data manually
         } catch {
             // ignore parse errors
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [titleParam]);
 
     // Suggestions stub (to be replaced with contacts provider)

--- a/frontend/components/views/calendar-view.tsx
+++ b/frontend/components/views/calendar-view.tsx
@@ -1,4 +1,4 @@
-import { useIntegrations } from '@/contexts/integrations-context';
+gitimport { useIntegrations } from '@/contexts/integrations-context';
 import { useUserPreferences } from '@/contexts/settings-context';
 import { gatewayClient } from '@/lib/gateway-client';
 import type { CalendarEvent } from '@/types/office-service';

--- a/frontend/components/views/calendar-view.tsx
+++ b/frontend/components/views/calendar-view.tsx
@@ -1,4 +1,4 @@
-gitimport { useIntegrations } from '@/contexts/integrations-context';
+import { useIntegrations } from '@/contexts/integrations-context';
 import { useUserPreferences } from '@/contexts/settings-context';
 import { gatewayClient } from '@/lib/gateway-client';
 import type { CalendarEvent } from '@/types/office-service';


### PR DESCRIPTION
Adds a 'Create Meeting Poll' option to email thread card and header menus, pre-populating participants from email recipients.

---
<a href="https://cursor.com/background-agent?bcId=bc-64152ce1-4116-4a19-a1cd-c1f377b0bba4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-64152ce1-4116-4a19-a1cd-c1f377b0bba4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

