### PR TITLE
feat: add typecheck npm script for TypeScript validation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
         "build": "next build",
         "start": "next start",
         "lint": "next lint",
-        "test": "jest"
+        "test": "jest",
+        "typecheck": "npx tsc --noEmit"
     },
     "dependencies": {
         "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
- Add 'typecheck' script that runs 'npx tsc --noEmit'
- Provides convenient way to validate TypeScript types without compilation
- Useful for CI/CD pipelines and development workflow
- Complements existing lint and test scripts