### PR TITLE
test: prevent vespa test from making http calls

### DIFF
--- a/services/vespa_query/tests/test_vespa_flow.py
+++ b/services/vespa_query/tests/test_vespa_flow.py
@@ -95,37 +95,39 @@ VespaClient = MockVespaClient
 # Commented out to prevent HTTP calls during module loading:
 # from services.vespa_query.search_engine import SearchEngine
 
+
 # Mock SearchEngine class
 class MockSearchEngine:
     def __init__(self, endpoint: str):
         self.endpoint = endpoint
-    
+
     async def search(self, query):
         return {"results": [], "total": 0}
-    
+
     async def autocomplete(self, query):
         return {"suggestions": [], "total": 0}
-    
+
     async def get_facets(self, query):
         return {"facets": {}, "total": 0}
-    
+
     async def get_trending(self, query):
         return {"trending": [], "total": 0}
-    
+
     async def get_analytics(self, query):
         return {"analytics": {}, "total": 0}
-    
+
     async def find_similar(self, query):
         return {"similar": [], "total": 0}
-    
+
     async def start(self):
         pass
-    
+
     async def close(self):
         pass
-    
+
     async def test_connection(self):
         return True
+
 
 SearchEngine = MockSearchEngine
 
@@ -176,7 +178,9 @@ class TestVespaDataFlow(BaseIntegrationTest):
         try:
             # Since we're using mock clients, just log the cleanup
             # No real HTTP calls will be made
-            logger.info(f"Mock cleanup: Would delete {len(self.test_emails)} emails, {len(self.test_calendar_events)} events, {len(self.test_contacts)} contacts")
+            logger.info(
+                f"Mock cleanup: Would delete {len(self.test_emails)} emails, {len(self.test_calendar_events)} events, {len(self.test_contacts)} contacts"
+            )
             logger.info("Test data cleanup completed (mock mode)")
 
         except Exception as e:

--- a/services/vespa_query/tests/test_vespa_flow.py
+++ b/services/vespa_query/tests/test_vespa_flow.py
@@ -102,6 +102,30 @@ class MockSearchEngine:
     
     async def search(self, query):
         return {"results": [], "total": 0}
+    
+    async def autocomplete(self, query):
+        return {"suggestions": [], "total": 0}
+    
+    async def get_facets(self, query):
+        return {"facets": {}, "total": 0}
+    
+    async def get_trending(self, query):
+        return {"trending": [], "total": 0}
+    
+    async def get_analytics(self, query):
+        return {"analytics": {}, "total": 0}
+    
+    async def find_similar(self, query):
+        return {"similar": [], "total": 0}
+    
+    async def start(self):
+        pass
+    
+    async def close(self):
+        pass
+    
+    async def test_connection(self):
+        return True
 
 SearchEngine = MockSearchEngine
 
@@ -129,7 +153,7 @@ class TestVespaDataFlow(BaseIntegrationTest):
 
         # Initialize mock clients to prevent real HTTP calls
         self.vespa_client = MockVespaClient(self.config["vespa_endpoint"])
-        self.search_engine = None  # Mock this if needed
+        self.search_engine = MockSearchEngine(self.config["vespa_endpoint"])
         self.pubsub_publisher = MockPubSubPublisher(
             self.config["pubsub_project_id"], self.config["pubsub_emulator_host"]
         )

--- a/services/vespa_query/tests/test_vespa_flow.py
+++ b/services/vespa_query/tests/test_vespa_flow.py
@@ -105,16 +105,8 @@ class MockSearchEngine:
         # Return a structure that matches the real Vespa response
         # This prevents AttributeError in _wait_for_vespa_indexing and other methods
         return {
-            "root": {
-                "fields": {
-                    "totalCount": 0
-                },
-                "children": []
-            },
-            "performance": {
-                "query_time_ms": 0.1,
-                "timestamp": "2024-01-01T00:00:00"
-            }
+            "root": {"fields": {"totalCount": 0}, "children": []},
+            "performance": {"query_time_ms": 0.1, "timestamp": "2024-01-01T00:00:00"},
         }
 
     async def autocomplete(self, query):
@@ -136,24 +128,18 @@ class MockSearchEngine:
         # Mock batch search implementation that matches the real SearchEngine
         if not queries:
             return []
-        
+
         results = []
         for i, query in enumerate(queries):
             try:
                 # Simulate successful search for each query
                 search_result = await self.search(query)
-                results.append({
-                    "index": i,
-                    "status": "success",
-                    "result": search_result
-                })
+                results.append(
+                    {"index": i, "status": "success", "result": search_result}
+                )
             except Exception as e:
-                results.append({
-                    "index": i,
-                    "status": "error",
-                    "error": str(e)
-                })
-        
+                results.append({"index": i, "status": "error", "error": str(e)})
+
         return results
 
     async def start(self):

--- a/services/vespa_query/tests/test_vespa_flow.py
+++ b/services/vespa_query/tests/test_vespa_flow.py
@@ -102,7 +102,20 @@ class MockSearchEngine:
         self.endpoint = endpoint
 
     async def search(self, query):
-        return {"results": [], "total": 0}
+        # Return a structure that matches the real Vespa response
+        # This prevents AttributeError in _wait_for_vespa_indexing and other methods
+        return {
+            "root": {
+                "fields": {
+                    "totalCount": 0
+                },
+                "children": []
+            },
+            "performance": {
+                "query_time_ms": 0.1,
+                "timestamp": "2024-01-01T00:00:00"
+            }
+        }
 
     async def autocomplete(self, query):
         return {"suggestions": [], "total": 0}
@@ -118,6 +131,30 @@ class MockSearchEngine:
 
     async def find_similar(self, query):
         return {"similar": [], "total": 0}
+
+    async def batch_search(self, queries):
+        # Mock batch search implementation that matches the real SearchEngine
+        if not queries:
+            return []
+        
+        results = []
+        for i, query in enumerate(queries):
+            try:
+                # Simulate successful search for each query
+                search_result = await self.search(query)
+                results.append({
+                    "index": i,
+                    "status": "success",
+                    "result": search_result
+                })
+            except Exception as e:
+                results.append({
+                    "index": i,
+                    "status": "error",
+                    "error": str(e)
+                })
+        
+        return results
 
     async def start(self):
         pass


### PR DESCRIPTION
Fix slow test and HTTP calls in test_vespa_flow.py - use mock classes only to prevent real imports