### PR TITLE
fix: make time-slot-calendar test robust to date corner cases

### DIFF
--- a/frontend/components/meetings/__tests__/time-slot-calendar.test.tsx
+++ b/frontend/components/meetings/__tests__/time-slot-calendar.test.tsx
@@ -317,7 +317,8 @@ describe('TimeSlotCalendar Business Day Integration', () => {
         expect(screen.getByText(/showing \d+ days total \(business days only\)/i)).toBeInTheDocument();
 
         // Verify that the range calculation worked correctly by checking displayed dates
-        const dateHeaders = screen.getAllByText(/Aug \d+/);
+        // Use dynamic date matching instead of hardcoded month expectations
+        const dateHeaders = screen.getAllByText(/\w{3} \w{3} \d+/);
         expect(dateHeaders.length).toBeGreaterThan(0);
 
         // The component should be functional and responsive


### PR DESCRIPTION
The Problem:
The test was failing because it was looking for date headers matching /Aug \d+/ (e.g., "Aug 15"), but the component was using dynamic date calculations that could result in dates in different months (September, October, etc.). This caused the test to fail when FUTURE_FRIDAY was calculated to be in a month other than August.

Root Cause:
The test was using hardcoded month expectations (/Aug \d+/) while the component was dynamically calculating future dates that could span multiple months. This created a mismatch between what the test expected and what was actually displayed.

The Fix:
Replaced the hardcoded regex /Aug \d+/ with a more flexible pattern /\w{3} \w{3} \d+/ that matches any date format like "Mon Aug 5", "Tue Sep 10", etc. This makes the test robust to date corner cases where the target date might fall in different months.