### PR TITLE
ci: Add vespa_loader to OpenAPI schema and TypeScript type gen

### DIFF
--- a/frontend/types/api/vespa_loader/index.ts
+++ b/frontend/types/api/vespa_loader/index.ts
@@ -1,0 +1,7 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type { HTTPValidationError } from './models/HTTPValidationError';
+export type { ValidationError } from './models/ValidationError';

--- a/frontend/types/api/vespa_loader/models/HTTPValidationError.ts
+++ b/frontend/types/api/vespa_loader/models/HTTPValidationError.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ValidationError } from './ValidationError';
+export type HTTPValidationError = {
+    detail?: Array<ValidationError>;
+};
+

--- a/frontend/types/api/vespa_loader/models/ValidationError.ts
+++ b/frontend/types/api/vespa_loader/models/ValidationError.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ValidationError = {
+    loc: Array<(string | number)>;
+    msg: string;
+    type: string;
+};
+

--- a/scripts/generate-openapi-schemas.sh
+++ b/scripts/generate-openapi-schemas.sh
@@ -36,7 +36,7 @@ PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Service configuration
 # Services to exclude from OpenAPI generation (no meaningful schemas or not FastAPI apps)
-EXCLUDED_SERVICES="common vector_db email_sync demos vespa_loader briefly.egg-info __pycache__"
+EXCLUDED_SERVICES="common vector_db email_sync demos briefly.egg-info __pycache__"
 
 # Auto-discover services
 discover_services() {

--- a/scripts/update-types.sh
+++ b/scripts/update-types.sh
@@ -163,7 +163,7 @@ update_all_types() {
     echo "=================================================================="
     
     # Services to exclude from frontend type generation (same as generate-openapi-schemas.sh)
-    local EXCLUDED_SERVICES="common vector_db email_sync demos vespa_loader briefly.egg-info __pycache__"
+    local EXCLUDED_SERVICES="common vector_db email_sync demos briefly.egg-info __pycache__"
     
     # Get list of services that have OpenAPI schemas
     local services=()


### PR DESCRIPTION
- Remove vespa_loader from EXCLUDED_SERVICES in both scripts
- vespa_loader has FastAPI endpoints and should generate schemas
- Now generates OpenAPI schema and TypeScript types for vespa_loader