### PR TITLE
fix(be): user database hangs mitigated by implementing shared engine

### DIFF
--- a/services/user/database.py
+++ b/services/user/database.py
@@ -48,8 +48,8 @@ def get_engine() -> AsyncEngine:
 
         # Prepare connect_args based on database type
         connect_args = {}
-        if db_url.startswith("postgresql://"):
-            # PostgreSQL-specific statement timeout
+        if db_url.startswith("postgresql"):
+            # PostgreSQL-specific statement timeout (covers all drivers: postgresql://, postgresql+asyncpg://, etc.)
             connect_args["options"] = "-c statement_timeout=10000"
 
         _engine = create_async_engine(

--- a/services/user/database.py
+++ b/services/user/database.py
@@ -4,7 +4,7 @@ Database configuration for User Management Service.
 Sets up database connection using SQLModel and SQLAlchemy.
 """
 
-from typing import AsyncGenerator, Optional
+from typing import Any, AsyncGenerator, Optional
 
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -29,7 +29,7 @@ _session_factory: Optional[async_sessionmaker[AsyncSession]] = None
 _settings = None
 
 
-def get_settings():
+def get_settings() -> Any:
     """Get or create the settings singleton."""
     global _settings
     if _settings is None:
@@ -52,6 +52,8 @@ def get_engine() -> AsyncEngine:
             max_overflow=20,
             pool_timeout=30,
             pool_recycle=3600,
+            # Set statement timeout to 10 seconds to prevent hanging queries
+            connect_args={"options": "-c statement_timeout=10000"},
         )
     return _engine
 

--- a/services/user/database.py
+++ b/services/user/database.py
@@ -4,7 +4,7 @@ Database configuration for User Management Service.
 Sets up database connection using SQLModel and SQLAlchemy.
 """
 
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Optional
 
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -22,24 +22,51 @@ from services.user.models.token import EncryptedToken  # noqa: F401
 
 # Import all models so SQLModel can find them for table creation
 from services.user.models.user import User  # noqa: F401
-from services.user.settings import get_settings
+
+# Global engine and session factory - created once and reused
+_engine: Optional[AsyncEngine] = None
+_session_factory: Optional[async_sessionmaker[AsyncSession]] = None
+_settings = None
+
+
+def get_settings():
+    """Get or create the settings singleton."""
+    global _settings
+    if _settings is None:
+        from services.user.settings import get_settings as _get_settings
+
+        _settings = _get_settings()
+    return _settings
 
 
 def get_engine() -> AsyncEngine:
-    settings = get_settings()
-    return create_async_engine(
-        get_async_database_url(settings.db_url_user),
-        echo=settings.debug,
-    )
+    """Get or create the shared database engine."""
+    global _engine
+    if _engine is None:
+        settings = get_settings()
+        _engine = create_async_engine(
+            get_async_database_url(settings.db_url_user),
+            echo=settings.debug,
+            # Add connection pool settings to prevent hangs
+            pool_size=10,
+            max_overflow=20,
+            pool_timeout=30,
+            pool_recycle=3600,
+        )
+    return _engine
 
 
 def get_async_session() -> async_sessionmaker[AsyncSession]:
-    engine = get_engine()
-    return async_sessionmaker(
-        engine,
-        class_=AsyncSession,
-        expire_on_commit=False,
-    )
+    """Get or create the shared session factory."""
+    global _session_factory
+    if _session_factory is None:
+        engine = get_engine()
+        _session_factory = async_sessionmaker(
+            engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+        )
+    return _session_factory
 
 
 # Database lifecycle management
@@ -67,5 +94,24 @@ async def create_all_tables_for_testing() -> None:
 
 async def close_db() -> None:
     """Close database connections."""
-    engine = get_engine()
-    await engine.dispose()
+    global _engine, _session_factory
+    if _engine:
+        await _engine.dispose()
+        _engine = None
+        _session_factory = None
+
+
+async def reset_db() -> None:
+    """Reset database connections (useful for testing)."""
+    global _engine, _session_factory, _settings
+    if _engine:
+        await _engine.dispose()
+        _engine = None
+        _session_factory = None
+        _settings = None
+
+
+def reset_settings() -> None:
+    """Reset settings singleton (useful for testing)."""
+    global _settings
+    _settings = None

--- a/services/user/services/integration_service.py
+++ b/services/user/services/integration_service.py
@@ -86,8 +86,6 @@ class IntegrationService:
             # Use a single database session for all operations with timeout protection
             async_session = get_async_session()
             async with async_session() as session:
-                # Set a reasonable timeout for database operations
-                session.bind.execution_options(timeout=10)  # 10 second timeout
 
                 # Verify user exists
                 result = await session.execute(


### PR DESCRIPTION
- Replace multiple engine creation with single shared engine and session factory 
- Add connection pool settings to prevent connection exhaustion 
- Optimize integration service to use single database session
- Add timeout protection to prevent indefinite hangs 
- Fixes 22+ second response times on integrations endpoint