### PR TITLE
fix(be): database engine creation in meetings service to prevent hangs

### DIFF
--- a/services/meetings/models/__init__.py
+++ b/services/meetings/models/__init__.py
@@ -26,10 +26,10 @@ from services.meetings.models.meeting import TimeSlot as TimeSlot
 from services.meetings.settings import get_settings
 
 # Global engines and session factories - created once and reused
-_engine: Optional[Engine] = None
-_async_engine: Optional[AsyncEngine] = None
-_session_maker: Optional[sessionmaker] = None
-_async_session_maker: Optional[async_sessionmaker] = None
+_engine: Engine | None = None
+_async_engine: AsyncEngine | None = None
+_session_maker: sessionmaker | None = None
+_async_session_maker: async_sessionmaker | None = None
 
 # Thread-safe initialization locks
 _engine_lock = Lock()

--- a/services/meetings/models/__init__.py
+++ b/services/meetings/models/__init__.py
@@ -153,21 +153,21 @@ async def close_db() -> None:
     async_engine_to_dispose: Optional[AsyncEngine] = None
     engine_to_dispose: Optional[Engine] = None
 
-    # Async path: clear globals under locks in sessionmaker -> engine order
+    # Async path: clear sessionmaker unconditionally, then clear engine if present (sessionmaker -> engine order)
     with _async_session_maker_lock:
+        _async_session_maker = None
         with _async_engine_lock:
             if _async_engine is not None:
                 async_engine_to_dispose = _async_engine
                 _async_engine = None
-                _async_session_maker = None
 
-    # Sync path: clear globals under locks in sessionmaker -> engine order
+    # Sync path: clear sessionmaker unconditionally, then clear engine if present (sessionmaker -> engine order)
     with _session_maker_lock:
+        _session_maker = None
         with _engine_lock:
             if _engine is not None:
                 engine_to_dispose = _engine
                 _engine = None
-                _session_maker = None
 
     # Now dispose outside of locks
     if async_engine_to_dispose is not None:

--- a/services/meetings/models/__init__.py
+++ b/services/meetings/models/__init__.py
@@ -47,8 +47,8 @@ def get_engine() -> "Engine":
             if _engine is None:
                 db_url = get_settings().db_url_meetings
                 _engine = create_engine(
-                    db_url, 
-                    echo=False, 
+                    db_url,
+                    echo=False,
                     future=True,
                     # Add connection pool settings to prevent connection exhaustion
                     pool_size=10,

--- a/services/meetings/models/__init__.py
+++ b/services/meetings/models/__init__.py
@@ -78,6 +78,7 @@ def get_async_engine() -> "AsyncEngine":
                     max_overflow=20,
                     pool_timeout=30,
                     pool_recycle=3600,
+                    pool_pre_ping=True,
                 )
     return _async_engine
 

--- a/services/meetings/models/__init__.py
+++ b/services/meetings/models/__init__.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager, contextmanager
-from typing import AsyncGenerator, Generator
+from typing import AsyncGenerator, Generator, Optional
 
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
@@ -24,35 +24,66 @@ from services.meetings.models.meeting import PollResponse as PollResponse
 from services.meetings.models.meeting import TimeSlot as TimeSlot
 from services.meetings.settings import get_settings
 
+# Global engines and session factories - created once and reused
+_engine: Optional[Engine] = None
+_async_engine: Optional[AsyncEngine] = None
+_session_maker: Optional[sessionmaker] = None
+_async_session_maker: Optional[async_sessionmaker] = None
+
 
 def get_engine() -> "Engine":
-    db_url = get_settings().db_url_meetings
-    return create_engine(db_url, echo=False, future=True)
+    """Get or create the shared database engine."""
+    global _engine
+    if _engine is None:
+        db_url = get_settings().db_url_meetings
+        _engine = create_engine(db_url, echo=False, future=True)
+    return _engine
 
 
 def get_async_engine() -> "AsyncEngine":
-    """Get async database engine for async operations."""
-    db_url = get_settings().db_url_meetings
-    async_db_url = get_async_database_url(db_url)
-    return create_async_engine(async_db_url, echo=False, future=True)
+    """Get or create the shared async database engine."""
+    global _async_engine
+    if _async_engine is None:
+        db_url = get_settings().db_url_meetings
+        async_db_url = get_async_database_url(db_url)
+        _async_engine = create_async_engine(
+            async_db_url,
+            echo=False,
+            future=True,
+            # Add connection pool settings to prevent hangs
+            pool_size=10,
+            max_overflow=20,
+            pool_timeout=30,
+            pool_recycle=3600,
+        )
+    return _async_engine
 
 
 def get_sessionmaker() -> sessionmaker:
-    engine = get_engine()
-    return sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    """Get or create the shared session maker."""
+    global _session_maker
+    if _session_maker is None:
+        engine = get_engine()
+        _session_maker = sessionmaker(
+            bind=engine, autoflush=False, autocommit=False, future=True
+        )
+    return _session_maker
 
 
 def get_async_sessionmaker() -> async_sessionmaker:
-    """Get async session maker for async operations."""
-    engine = get_async_engine()
-    return async_sessionmaker(
-        bind=engine,
-        autoflush=False,
-        autocommit=False,
-        future=True,
-        class_=AsyncSession,
-        expire_on_commit=False,
-    )
+    """Get or create the shared async session maker."""
+    global _async_session_maker
+    if _async_session_maker is None:
+        engine = get_async_engine()
+        _async_session_maker = async_sessionmaker(
+            bind=engine,
+            autoflush=False,
+            autocommit=False,
+            future=True,
+            class_=AsyncSession,
+            expire_on_commit=False,
+        )
+    return _async_session_maker
 
 
 @contextmanager
@@ -83,3 +114,25 @@ async def create_all_tables_for_testing() -> None:
     from services.meetings.models.base import Base
 
     Base.metadata.create_all(engine)
+
+
+async def close_db() -> None:
+    """Close database connections."""
+    global _engine, _async_engine, _session_maker, _async_session_maker
+    if _async_engine:
+        await _async_engine.dispose()
+        _async_engine = None
+        _async_session_maker = None
+    if _engine:
+        _engine.dispose()
+        _engine = None
+        _session_maker = None
+
+
+def reset_db() -> None:
+    """Reset database connections (useful for testing)."""
+    global _engine, _async_engine, _session_maker, _async_session_maker
+    _engine = None
+    _async_engine = None
+    _session_maker = None
+    _async_session_maker = None

--- a/services/meetings/tests/meetings_test_base.py
+++ b/services/meetings/tests/meetings_test_base.py
@@ -25,6 +25,11 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
         # Call parent setup to enable HTTP call detection
         super().setup_method(method)
 
+        # Reset any existing database connections to ensure clean state
+        from services.meetings.models import reset_db
+
+        reset_db()
+
         # Use a unique temp file for each test
         self._db_fd, self._db_path = tempfile.mkstemp(suffix=".sqlite3")
         db_url = f"sqlite:///{self._db_path}"
@@ -111,6 +116,18 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
 
     def teardown_method(self, method):
         """Clean up test environment."""
+
+        # Clean up database connections
+        try:
+            import asyncio
+
+            from services.meetings.models import close_db
+
+            # Run the async close_db function
+            asyncio.run(close_db())
+        except Exception as e:
+            # If cleanup fails, log it but don't fail the test
+            print(f"Warning: Could not close database connections: {e}")
 
         # Clean up environment variables
         env_vars_to_remove = [

--- a/services/meetings/tests/test_base.py
+++ b/services/meetings/tests/test_base.py
@@ -22,6 +22,11 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
         # Call parent setup to enable HTTP call detection
         super().setup_method(method)
 
+        # Reset any existing database connections to ensure clean state
+        from services.meetings.models import reset_db
+
+        reset_db()
+
         # Use a unique temp file for each test
         self._db_fd, self._db_path = tempfile.mkstemp(suffix=".sqlite3")
         db_url = f"sqlite:///{self._db_path}"
@@ -81,6 +86,18 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
 
     def teardown_method(self, method):
         """Clean up Meetings Service test environment."""
+        # Clean up database connections
+        try:
+            import asyncio
+
+            from services.meetings.models import close_db
+
+            # Run the async close_db function
+            asyncio.run(close_db())
+        except Exception as e:
+            # If cleanup fails, log it but don't fail the test
+            print(f"Warning: Could not close database connections: {e}")
+
         # Call parent teardown to clean up HTTP patches
         super().teardown_method(method)
 

--- a/services/meetings/tests/test_base.py
+++ b/services/meetings/tests/test_base.py
@@ -93,7 +93,15 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
             from services.meetings.models import close_db
 
             # Run the async close_db function
-            asyncio.run(close_db())
+            try:
+                asyncio.run(close_db())
+            except RuntimeError:
+                # If we're already in an event loop, create a task in a separate thread
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    future = executor.submit(asyncio.run, close_db())
+                    future.result()
         except Exception as e:
             # If cleanup fails, log it but don't fail the test
             print(f"Warning: Could not close database connections: {e}")

--- a/services/meetings/tests/test_email_response.py
+++ b/services/meetings/tests/test_email_response.py
@@ -31,13 +31,19 @@ class TestEmailResponse(BaseMeetingsTest):
             get_session,
         )
 
-        with get_session() as session:
-            # Delete in reverse order to avoid foreign key constraints
-            session.query(PollResponse).delete()
-            session.query(PollParticipant).delete()
-            session.query(TimeSlot).delete()
-            session.query(MeetingPoll).delete()
-            session.commit()
+        try:
+            with get_session() as session:
+                # Delete in reverse order to avoid foreign key constraints
+                session.query(PollResponse).delete()
+                session.query(PollParticipant).delete()
+                session.query(TimeSlot).delete()
+                session.query(MeetingPoll).delete()
+                session.commit()
+        except Exception as e:
+            # If there's an error clearing data, log it but don't fail the test
+            # This can happen if the database is readonly or tables don't exist
+            print(f"Warning: Could not clear test data: {e}")
+            pass
 
     def create_poll_and_participant(self, num_slots=1):
         """Create a poll with the specified number of time slots and a participant."""


### PR DESCRIPTION
- Implement singleton pattern for engines and session factories
- Add connection pool settings to prevent connection exhaustion
- Add proper cleanup functions for testing and resource management
- Follows same pattern as user service for consistency