### PR TITLE
fix(be): log formatting in contact message processing

### DIFF
--- a/services/vespa_loader/pubsub_consumer.py
+++ b/services/vespa_loader/pubsub_consumer.py
@@ -788,7 +788,7 @@ class PubSubConsumer:
                     # Log contact processing with key details in one line
                     logger.info(
                         f"Processing contact {i+1}/{len(data.contacts)}: "
-                        f"ID={contact.id}, Name='{(contact.given_name or '') + ' ' + (contact.family_name or '')}'.strip(), "
+                        f"ID={contact.id}, Name='{((contact.given_name or '') + ' ' + (contact.family_name or '')).strip()}', "
                         f"Provider={contact.provider}"
                     )
 


### PR DESCRIPTION
Fixes a logging bug where `.strip()` appeared as literal text and contact names were not stripped of whitespace.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8bc63ea-1e8f-4b7d-a24c-94ca681756ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8bc63ea-1e8f-4b7d-a24c-94ca681756ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

