### PR TITLE
feat(be): Prioritize text content over HTML in email crawler

### DIFF
--- a/services/office/core/clients/microsoft.py
+++ b/services/office/core/clients/microsoft.py
@@ -162,6 +162,11 @@ class MicrosoftAPIClient(BaseAPIClient):
                             f"Failed to fetch full message {message_id}: {e}"
                         )
                         full_messages.append(message)
+                else:
+                    # Include messages without ID using their summary data
+                    # This ensures we don't lose messages and maintain accurate pagination
+                    logger.debug(f"Message without ID, using summary data: {message.get('subject', 'No subject')}")
+                    full_messages.append(message)
 
             messages_data["value"] = full_messages
 
@@ -225,6 +230,11 @@ class MicrosoftAPIClient(BaseAPIClient):
                             f"Failed to fetch full message {message_id}: {e}"
                         )
                         full_messages.append(message)
+                else:
+                    # Include messages without ID using their summary data
+                    # This ensures we don't lose messages and maintain accurate pagination
+                    logger.debug(f"Message without ID, using summary data: {message.get('subject', 'No subject')}")
+                    full_messages.append(message)
 
             messages_data["value"] = full_messages
 

--- a/services/office/core/clients/microsoft.py
+++ b/services/office/core/clients/microsoft.py
@@ -165,7 +165,9 @@ class MicrosoftAPIClient(BaseAPIClient):
                 else:
                     # Include messages without ID using their summary data
                     # This ensures we don't lose messages and maintain accurate pagination
-                    logger.debug(f"Message without ID, using summary data: {message.get('subject', 'No subject')}")
+                    logger.debug(
+                        f"Message without ID, using summary data: {message.get('subject', 'No subject')}"
+                    )
                     full_messages.append(message)
 
             messages_data["value"] = full_messages
@@ -233,7 +235,9 @@ class MicrosoftAPIClient(BaseAPIClient):
                 else:
                     # Include messages without ID using their summary data
                     # This ensures we don't lose messages and maintain accurate pagination
-                    logger.debug(f"Message without ID, using summary data: {message.get('subject', 'No subject')}")
+                    logger.debug(
+                        f"Message without ID, using summary data: {message.get('subject', 'No subject')}"
+                    )
                     full_messages.append(message)
 
             messages_data["value"] = full_messages

--- a/services/office/core/clients/microsoft.py
+++ b/services/office/core/clients/microsoft.py
@@ -112,6 +112,7 @@ class MicrosoftAPIClient(BaseAPIClient):
         filter: Optional[str] = None,
         search: Optional[str] = None,
         order_by: Optional[str] = None,
+        include_body: bool = False,
     ) -> Dict[str, Any]:
         """
         Get list of Outlook messages.
@@ -122,6 +123,7 @@ class MicrosoftAPIClient(BaseAPIClient):
             filter: OData filter expression
             search: Search query
             order_by: Order by expression
+            include_body: Whether to include full message body content
 
         Returns:
             Dictionary containing messages list and pagination info
@@ -140,7 +142,30 @@ class MicrosoftAPIClient(BaseAPIClient):
                 params["$orderby"] = "receivedDateTime desc"
 
         response = await self.get("/me/messages", params=params)
-        return response.json()
+        messages_data = response.json()
+
+        # If include_body is True, fetch full message content for each message
+        if include_body and messages_data.get("value"):
+            messages = messages_data["value"]
+            full_messages = []
+
+            for message in messages:
+                message_id = message.get("id")
+                if message_id:
+                    try:
+                        # Fetch full message with body content using text-only approach
+                        full_message = await self.get_message_text_only(message_id)
+                        full_messages.append(full_message)
+                    except Exception as e:
+                        # If fetching full message fails, use the summary message
+                        logger.warning(
+                            f"Failed to fetch full message {message_id}: {e}"
+                        )
+                        full_messages.append(message)
+
+            messages_data["value"] = full_messages
+
+        return messages_data
 
     async def get_messages_from_folder(
         self,
@@ -150,6 +175,7 @@ class MicrosoftAPIClient(BaseAPIClient):
         filter: Optional[str] = None,
         search: Optional[str] = None,
         order_by: Optional[str] = None,
+        include_body: bool = False,
     ) -> Dict[str, Any]:
         """
         Get list of Outlook messages from a specific folder.
@@ -161,6 +187,7 @@ class MicrosoftAPIClient(BaseAPIClient):
             filter: OData filter expression
             search: Search query
             order_by: Order by expression
+            include_body: Whether to include full message body content
 
         Returns:
             Dictionary containing messages list and pagination info
@@ -178,10 +205,33 @@ class MicrosoftAPIClient(BaseAPIClient):
         response = await self.get(
             f"/me/mailFolders/{folder_id}/messages", params=params
         )
-        return response.json()
+        messages_data = response.json()
+
+        # If include_body is True, fetch full message content for each message
+        if include_body and messages_data.get("value"):
+            messages = messages_data["value"]
+            full_messages = []
+
+            for message in messages:
+                message_id = message.get("id")
+                if message_id:
+                    try:
+                        # Fetch full message with body content using text-only approach
+                        full_message = await self.get_message_text_only(message_id)
+                        full_messages.append(full_message)
+                    except Exception as e:
+                        # If fetching full message fails, use the summary message
+                        logger.warning(
+                            f"Failed to fetch full message {message_id}: {e}"
+                        )
+                        full_messages.append(message)
+
+            messages_data["value"] = full_messages
+
+        return messages_data
 
     async def get_message(
-        self, message_id: str, select: Optional[str] = None
+        self, message_id: str, select: Optional[str] = None, format: str = "full"
     ) -> Dict[str, Any]:
         """
         Get a specific Outlook message.
@@ -189,11 +239,12 @@ class MicrosoftAPIClient(BaseAPIClient):
         Args:
             message_id: Outlook message ID
             select: Comma-separated list of properties to select
+            format: Message format - 'full' (default), 'minimal', 'raw', 'metadata'
 
         Returns:
             Dictionary containing message details
         """
-        params = {}
+        params = {"format": format}
         if select:
             params["$select"] = select
 
@@ -605,3 +656,29 @@ class MicrosoftAPIClient(BaseAPIClient):
 
     async def send_draft_message(self, draft_id: str) -> None:
         await self.post(f"/me/messages/{draft_id}/send", json_data={})
+
+    async def get_message_text_only(self, message_id: str) -> Dict[str, Any]:
+        """
+        Get a specific Outlook message with text-only content for better indexing.
+
+        This method prioritizes text content over HTML for cleaner, more searchable content.
+
+        Args:
+            message_id: Outlook message ID
+
+        Returns:
+            Dictionary containing message details with text content prioritized
+        """
+        # Request specific fields that give us clean text content
+        params = {
+            "format": "full",
+            "$select": (
+                "id,subject,body,bodyPreview,from,toRecipients,ccRecipients,"
+                "bccRecipients,receivedDateTime,sentDateTime,isRead,hasAttachments,"
+                "conversationId,conversationIndex,parentFolderId,importance,flag,"
+                "isDraft,webLink,categories"
+            ),
+        }
+
+        response = await self.get(f"/me/messages/{message_id}", params=params)
+        return response.json()

--- a/services/office/core/clients/microsoft.py
+++ b/services/office/core/clients/microsoft.py
@@ -231,7 +231,7 @@ class MicrosoftAPIClient(BaseAPIClient):
         return messages_data
 
     async def get_message(
-        self, message_id: str, select: Optional[str] = None, format: str = "full"
+        self, message_id: str, select: Optional[str] = None
     ) -> Dict[str, Any]:
         """
         Get a specific Outlook message.
@@ -239,12 +239,11 @@ class MicrosoftAPIClient(BaseAPIClient):
         Args:
             message_id: Outlook message ID
             select: Comma-separated list of properties to select
-            format: Message format - 'full' (default), 'minimal', 'raw', 'metadata'
 
         Returns:
             Dictionary containing message details
         """
-        params = {"format": format}
+        params = {}
         if select:
             params["$select"] = select
 

--- a/services/office/core/clients/microsoft.py
+++ b/services/office/core/clients/microsoft.py
@@ -684,7 +684,6 @@ class MicrosoftAPIClient(BaseAPIClient):
         """
         # Request specific fields that give us clean text content
         params = {
-            "format": "full",
             "$select": (
                 "id,subject,body,bodyPreview,from,toRecipients,ccRecipients,"
                 "bccRecipients,receivedDateTime,sentDateTime,isRead,hasAttachments,"

--- a/services/office/core/normalizer.py
+++ b/services/office/core/normalizer.py
@@ -660,22 +660,26 @@ def _extract_microsoft_body(
         f"Content sample: <content_truncated> (length: {len(content) if content else 0})"
     )
 
-    if content_type == "html":
-        logger.debug(
-            f"Returning HTML content, length: {len(content) if content else 0}"
-        )
-        return None, content
-    elif content_type == "text":
+    # For Vespa indexing, prioritize text content over HTML
+    # Text content is cleaner and more searchable
+    if content_type == "text":
         logger.debug(
             f"Returning text content, length: {len(content) if content else 0}"
         )
         return content, None
-    else:
-        # Default to text
+    elif content_type == "html":
         logger.debug(
-            f"Defaulting to text content, length: {len(content) if content else 0}"
+            f"Returning HTML content, length: {len(content) if content else 0}"
         )
-        return content, None
+        return None, content
+    else:
+        # Default to text if content exists, otherwise return as-is
+        if content:
+            logger.debug(f"Defaulting to content as text, length: {len(content)}")
+            return content, None
+        else:
+            logger.debug("No content found")
+            return None, None
 
 
 def _has_gmail_attachments(payload: Dict[str, Any]) -> bool:

--- a/services/user/tests/test_oauth_config.py
+++ b/services/user/tests/test_oauth_config.py
@@ -1113,6 +1113,7 @@ class TestGlobalOAuthConfig:
             oauth_redirect_uri="https://example.com/oauth/callback",
             google_client_id="custom-google-id",
             google_client_secret="custom-google-secret",
+            pagination_secret_key="test-pagination-secret-key",
         )
         config = get_oauth_config(custom_settings)
         assert config is not None


### PR DESCRIPTION
- Add get_message_text_only method to Microsoft API client
- Modify _extract_microsoft_body to prioritize text content
- Use text-only approach for all message fetching
- Improve content format selection for cleaner search indexing