### PR TITLE
test: prevent live HTTP calls in tests in meetings

### DIFF
--- a/services/common/test_utils.py
+++ b/services/common/test_utils.py
@@ -99,12 +99,18 @@ class BaseOfficeServiceIntegrationTest(BaseIntegrationTest):
         """Set up Office Service specific test environment."""
         # Use selective HTTP patches that don't interfere with TestClient
         self.http_patches = [
-            # Patch async httpx client (most likely to be used for real external calls)
+            # Patch httpx AsyncClient methods (most common for async HTTP calls)
             patch(
                 "httpx.AsyncClient._send_single_request",
                 side_effect=AssertionError(
                     "Real HTTP call detected! AsyncClient._send_single_request was "
                     "called"
+                ),
+            ),
+            patch(
+                "httpx.AsyncClient.request",
+                side_effect=AssertionError(
+                    "Real HTTP call detected! AsyncClient.request was called"
                 ),
             ),
             # Patch requests (commonly used for external calls)
@@ -114,6 +120,12 @@ class BaseOfficeServiceIntegrationTest(BaseIntegrationTest):
                     "Real HTTP call detected! requests HTTPAdapter.send was called"
                 ),
             ),
+            patch(
+                "requests.Session.request",
+                side_effect=AssertionError(
+                    "Real HTTP call detected! requests.Session.request was called"
+                ),
+            ),
             # Patch urllib (basic HTTP library)
             patch(
                 "urllib.request.urlopen",
@@ -121,8 +133,14 @@ class BaseOfficeServiceIntegrationTest(BaseIntegrationTest):
                     "Real HTTP call detected! urllib.request.urlopen was called"
                 ),
             ),
+            patch(
+                "urllib3.poolmanager.PoolManager.urlopen",
+                side_effect=AssertionError(
+                    "Real HTTP call detected! urllib3.PoolManager.urlopen was called"
+                ),
+            ),
             # Note: We don't patch httpx.Client.send because TestClient uses it
-            # internally
+            # internally for FastAPI test calls
         ]
 
         # Start all HTTP detection patches
@@ -198,11 +216,18 @@ class BaseSelectiveHTTPIntegrationTest(BaseIntegrationTest):
         # calls
 
         self.http_patches = [
+            # Patch httpx AsyncClient methods (most common for async HTTP calls)
             patch(
                 "httpx.AsyncClient._send_single_request",
                 side_effect=AssertionError(
                     "Real HTTP call detected! AsyncClient._send_single_request was "
                     "called"
+                ),
+            ),
+            patch(
+                "httpx.AsyncClient.request",
+                side_effect=AssertionError(
+                    "Real HTTP call detected! AsyncClient.request was called"
                 ),
             ),
             # Patch requests (commonly used for external calls)
@@ -212,6 +237,12 @@ class BaseSelectiveHTTPIntegrationTest(BaseIntegrationTest):
                     "Real HTTP call detected! requests HTTPAdapter.send was called"
                 ),
             ),
+            patch(
+                "requests.Session.request",
+                side_effect=AssertionError(
+                    "Real HTTP call detected! requests.Session.request was called"
+                ),
+            ),
             # Patch urllib (basic HTTP library)
             patch(
                 "urllib.request.urlopen",
@@ -219,8 +250,14 @@ class BaseSelectiveHTTPIntegrationTest(BaseIntegrationTest):
                     "Real HTTP call detected! urllib.request.urlopen was called"
                 ),
             ),
+            patch(
+                "urllib3.poolmanager.PoolManager.urlopen",
+                side_effect=AssertionError(
+                    "Real HTTP call detected! urllib3.PoolManager.urlopen was called"
+                ),
+            ),
             # Note: We don't patch httpx.Client.send because TestClient uses it
-            # internally
+            # internally for FastAPI test calls
         ]
 
         # Start all HTTP detection patches

--- a/services/demos/tests/test_demo_authentication.py
+++ b/services/demos/tests/test_demo_authentication.py
@@ -19,11 +19,20 @@ import pytest
 # Add the project root to the path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 
+from services.common.test_utils import BaseSelectiveHTTPIntegrationTest
 from services.demos.chat import FullDemo
 
 
-class TestDemoAuthentication:
+class TestDemoAuthentication(BaseSelectiveHTTPIntegrationTest):
     """Test suite for demo authentication flow."""
+
+    def setup_method(self, method):
+        """Set up test environment with HTTP call prevention."""
+        super().setup_method(method)
+
+    def teardown_method(self, method):
+        """Clean up test environment."""
+        super().teardown_method(method)
 
     @pytest.fixture
     def demo_instance(self):

--- a/services/meetings/tests/meetings_test_base.py
+++ b/services/meetings/tests/meetings_test_base.py
@@ -68,13 +68,13 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
 
         # Create a new FastAPI app instance to avoid reloading the main module
         # This ensures the app uses the updated settings without breaking mocks
-        app = FastAPI(
+        self.app = FastAPI(
             title="Briefly Meetings Service Test",
             version="0.1.0",
             description="Meeting scheduling and polling microservice for Briefly (Test).",
         )
 
-        app.add_middleware(
+        self.app.add_middleware(
             CORSMiddleware,
             allow_origins=["*"],
             allow_credentials=True,
@@ -83,28 +83,28 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
         )
 
         # Add request logging middleware
-        app.middleware("http")(create_request_logging_middleware())
+        self.app.middleware("http")(create_request_logging_middleware())
 
         # Register standardized exception handlers
-        register_briefly_exception_handlers(app)
+        register_briefly_exception_handlers(self.app)
 
-        app.include_router(
+        self.app.include_router(
             polls_router, prefix="/api/v1/meetings/polls", tags=["polls"]
         )
-        app.include_router(
+        self.app.include_router(
             slots_router,
             prefix="/api/v1/meetings/polls/{poll_id}/slots",
             tags=["slots"],
         )
-        app.include_router(
+        self.app.include_router(
             invitations_router,
             prefix="/api/v1/meetings/polls/{poll_id}/send-invitations",
             tags=["invitations"],
         )
-        app.include_router(
+        self.app.include_router(
             public_router, prefix="/api/v1/public/polls", tags=["public"]
         )
-        app.include_router(
+        self.app.include_router(
             email_router,
             prefix="/api/v1/meetings/process-email-response",
             tags=["email"],
@@ -112,7 +112,7 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
 
         from fastapi.testclient import TestClient
 
-        self.client = TestClient(app)
+        self.client = TestClient(self.app)
 
     def teardown_method(self, method):
         """Clean up test environment."""

--- a/services/meetings/tests/meetings_test_base.py
+++ b/services/meetings/tests/meetings_test_base.py
@@ -25,6 +25,10 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
         # Call parent setup to enable HTTP call detection
         super().setup_method(method)
 
+        # Disable rate limiting for tests
+        from services.meetings.services.security import set_test_mode
+        set_test_mode(True)
+
         # Reset any existing database connections to ensure clean state
         from services.meetings.models import reset_db
 
@@ -59,6 +63,7 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
 
         # Import API modules to ensure they're loaded with the test session
         from services.meetings.api import (
+            bookings_router,
             email_router,
             invitations_router,
             polls_router,
@@ -108,6 +113,11 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
             email_router,
             prefix="/api/v1/meetings/process-email-response",
             tags=["email"],
+        )
+        
+        # Include booking endpoints router
+        self.app.include_router(
+            bookings_router, prefix="/api/v1/bookings", tags=["bookings"]
         )
 
         from fastapi.testclient import TestClient

--- a/services/meetings/tests/meetings_test_base.py
+++ b/services/meetings/tests/meetings_test_base.py
@@ -160,4 +160,29 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
             os.close(self._db_fd)
         if hasattr(self, "_db_path") and os.path.exists(self._db_path):
             os.unlink(self._db_path)
+
+        # Call parent teardown to clean up HTTP patches
         super().teardown_method(method)
+
+
+class BaseMeetingsIntegrationTest(BaseMeetingsTest):
+    """Base class for Meetings Service integration tests with full app setup."""
+
+    def setup_method(self, method):
+        """Set up Meetings Service integration test environment."""
+        # Call parent setup for environment variables and database
+        super().setup_method(method)
+
+        # Create test client using app from base class
+        from fastapi.testclient import TestClient
+
+        self.client = TestClient(self.app)
+
+        # Set up authentication overrides if needed
+        self._override_auth()
+
+    def _override_auth(self):
+        """Override authentication for testing."""
+        # Override authentication dependencies if needed for testing
+        # This can be customized based on specific test requirements
+        pass

--- a/services/meetings/tests/meetings_test_base.py
+++ b/services/meetings/tests/meetings_test_base.py
@@ -27,6 +27,7 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
 
         # Disable rate limiting for tests
         from services.meetings.services.security import set_test_mode
+
         set_test_mode(True)
 
         # Reset any existing database connections to ensure clean state
@@ -114,7 +115,7 @@ class BaseMeetingsTest(BaseSelectiveHTTPIntegrationTest):
             prefix="/api/v1/meetings/process-email-response",
             tags=["email"],
         )
-        
+
         # Include booking endpoints router
         self.app.include_router(
             bookings_router, prefix="/api/v1/bookings", tags=["bookings"]

--- a/services/meetings/tests/test_availability_service.py
+++ b/services/meetings/tests/test_availability_service.py
@@ -26,7 +26,7 @@ from services.meetings.services.booking_availability import (
     _is_within_business_hours,
     compute_available_slots,
 )
-from services.meetings.tests.test_base import BaseMeetingsTest
+from services.meetings.tests.meetings_test_base import BaseMeetingsTest
 
 
 class TestAvailabilityService(BaseMeetingsTest):

--- a/services/meetings/tests/test_booking_endpoints.py
+++ b/services/meetings/tests/test_booking_endpoints.py
@@ -15,7 +15,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from services.meetings.models.booking_entities import BookingLink, OneTimeLink
-from services.meetings.tests.test_base import BaseMeetingsIntegrationTest
+from services.meetings.tests.meetings_test_base import BaseMeetingsIntegrationTest
 
 
 class TestBookingEndpoints(BaseMeetingsIntegrationTest):

--- a/services/meetings/tests/test_booking_endpoints.py
+++ b/services/meetings/tests/test_booking_endpoints.py
@@ -95,7 +95,7 @@ class TestBookingEndpoints(BaseMeetingsIntegrationTest):
         """Helper method to create a test booking link."""
         if slug_suffix is None:
             slug_suffix = str(uuid.uuid4())[:8]
-        
+
         booking_link = BookingLink(
             id=uuid.uuid4(),  # Use unique ID for each test
             owner_user_id=self.test_user_id,
@@ -117,7 +117,7 @@ class TestBookingEndpoints(BaseMeetingsIntegrationTest):
         """Helper method to create a test one-time link."""
         if token_suffix is None:
             token_suffix = str(uuid.uuid4())[:8]
-        
+
         one_time_link = OneTimeLink(
             id=uuid.uuid4(),
             token=f"{self.test_token}-{token_suffix}",

--- a/services/meetings/tests/test_calendar_integration.py
+++ b/services/meetings/tests/test_calendar_integration.py
@@ -15,7 +15,7 @@ import httpx
 import pytest
 
 from services.meetings.services.calendar_integration import get_user_availability
-from services.meetings.tests.test_base import BaseMeetingsTest
+from services.meetings.tests.meetings_test_base import BaseMeetingsTest
 
 
 class TestCalendarIntegration(BaseMeetingsTest):

--- a/services/meetings/tests/test_security.py
+++ b/services/meetings/tests/test_security.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from services.meetings.services.security import SecurityUtils, check_rate_limit
-from services.meetings.tests.test_base import BaseMeetingsTest
+from services.meetings.tests.meetings_test_base import BaseMeetingsTest
 
 
 class TestSecurityService(BaseMeetingsTest):

--- a/services/user/tests/test_base.py
+++ b/services/user/tests/test_base.py
@@ -57,11 +57,17 @@ class BaseUserManagementIntegrationTest(BaseUserManagementTest):
 
         # Use selective HTTP patches that don't interfere with TestClient
         self.http_patches = [
-            # Patch async httpx client (most likely to be used for real external calls)
+            # Patch httpx AsyncClient methods (most common for async HTTP calls)
             patch(
                 "httpx.AsyncClient._send_single_request",
                 side_effect=AssertionError(
                     "Real HTTP call detected! AsyncClient._send_single_request was called"
+                ),
+            ),
+            patch(
+                "httpx.AsyncClient.request",
+                side_effect=AssertionError(
+                    "Real HTTP call detected! AsyncClient.request was called"
                 ),
             ),
             # Patch requests (commonly used for external calls)
@@ -71,11 +77,23 @@ class BaseUserManagementIntegrationTest(BaseUserManagementTest):
                     "Real HTTP call detected! requests HTTPAdapter.send was called"
                 ),
             ),
+            patch(
+                "requests.Session.request",
+                side_effect=AssertionError(
+                    "Real HTTP call detected! requests.Session.request was called"
+                ),
+            ),
             # Patch urllib (basic HTTP library)
             patch(
                 "urllib.request.urlopen",
                 side_effect=AssertionError(
                     "Real HTTP call detected! urllib.request.urlopen was called"
+                ),
+            ),
+            patch(
+                "urllib3.poolmanager.PoolManager.urlopen",
+                side_effect=AssertionError(
+                    "Real HTTP call detected! urllib3.PoolManager.urlopen was called"
                 ),
             ),
             # Note: We don't patch httpx.Client.send because TestClient uses it internally


### PR DESCRIPTION
- Consolidate duplicate meetings test base classes into single file
- Fix demos test to inherit from proper base class with HTTP prevention
- Enhance HTTP call detection to catch more HTTP libraries
- Update all test imports to use unified base classes
- Add comprehensive HTTP call prevention patches for:
  - httpx.AsyncClient methods
  - requests.Session methods
  - urllib3.PoolManager methods