### PR TITLE
ci: only retrigger ci on push, not title change (except title check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,25 +6,11 @@ on:
   pull_request:
     branches: [ main, develop ]
     types: [opened, synchronize, ready_for_review, review_requested]
-  pull_request_target:
-    branches: [ main, develop ]
-    types: [edited]
 
 jobs:
-  validate-pr-title:
-    name: Validate PR Title
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # No specific `with` configuration needed, defaults are fine.
-        # All previous lines were comments after removing deprecated params.
-
   check-generated-files:
     name: Check Generated Files Are Up to Date
-    if: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -157,7 +143,6 @@ jobs:
 
   lint:
     name: Python Linting & Formatting
-    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -211,7 +196,6 @@ jobs:
 
   typecheck:
     name: Python Type Checking
-    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -250,7 +234,6 @@ jobs:
 
   test:
     name: Python Tests
-    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -288,7 +271,6 @@ jobs:
 
   coverage:
     name: Python Coverage
-    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -333,7 +315,6 @@ jobs:
 
   frontend-quality:
     name: Frontend Code Quality
-    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -379,7 +360,6 @@ jobs:
 
   docker-build:
     name: Docker Build Test
-    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
     runs-on: ubuntu-latest
     needs: [lint, typecheck, test, coverage, frontend-quality, check-generated-files]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,15 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
-    types: [opened, edited, synchronize]
+    types: [opened, synchronize, ready_for_review, review_requested]
+  pull_request_target:
+    branches: [ main, develop ]
+    types: [edited]
 
 jobs:
   validate-pr-title:
     name: Validate PR Title
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5
@@ -21,7 +24,7 @@ jobs:
 
   check-generated-files:
     name: Check Generated Files Are Up to Date
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -154,6 +157,7 @@ jobs:
 
   lint:
     name: Python Linting & Formatting
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -207,6 +211,7 @@ jobs:
 
   typecheck:
     name: Python Type Checking
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -245,6 +250,7 @@ jobs:
 
   test:
     name: Python Tests
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -282,6 +288,7 @@ jobs:
 
   coverage:
     name: Python Coverage
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -326,6 +333,7 @@ jobs:
 
   frontend-quality:
     name: Frontend Code Quality
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -371,6 +379,7 @@ jobs:
 
   docker-build:
     name: Docker Build Test
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
     runs-on: ubuntu-latest
     needs: [lint, typecheck, test, coverage, frontend-quality, check-generated-files]
 

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -1,0 +1,15 @@
+name: PR Title Validation
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    types: [opened, edited, synchronize, ready_for_review, review_requested]
+
+jobs:
+  validate-pr-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Separate PR title validation into dedicated workflow to prevent full CI re-runs on title/description changes