### PR TITLE
feat: add vespa.sh single invocation mode

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,65 @@
 
 This directory contains utility scripts for managing the Briefly platform.
 
+## Vespa Management Scripts
+
+### Vespa Management: `vespa.sh`
+
+A unified script for managing the Vespa search engine container and deploying the Briefly application.
+
+**Features:**
+- Start/stop/restart Vespa container
+- Deploy Briefly application to Vespa
+- Health checking and status reporting
+- Data clearing operations
+- **Single invocation** - automatically starts container and deploys app if needed
+
+**Usage:**
+```bash
+# Start container, deploy app, and show status (default - recommended)
+./scripts/vespa.sh
+
+# Same as above (explicit auto mode)
+./scripts/vespa.sh --auto
+
+# Start Vespa container only
+./scripts/vespa.sh --start
+
+# Deploy Briefly application only
+./scripts/vespa.sh --deploy
+
+# Show current status
+./scripts/vespa.sh --status
+
+# Stop Vespa container
+./scripts/vespa.sh --stop
+
+# Restart Vespa container
+./scripts/vespa.sh --restart
+
+# Clean up container
+./scripts/vespa.sh --cleanup
+
+# Clear data for specific user
+./scripts/vespa.sh --clear-data --email {email} --env-file {env_file} [--force]
+
+# Clear all data for all users
+./scripts/vespa.sh --clear-data-all-users
+
+# Show help
+./scripts/vespa.sh --help
+```
+
+**Key Benefits:**
+- 🚀 **Single command setup** - No more separate `--start` and `--deploy` calls
+- 🔍 **Smart health checks** - Automatically detects what needs to be done
+- 📦 **Automatic deployment** - Deploys Briefly app if not already deployed
+- 📊 **Comprehensive status** - Shows container and application status
+
+**Prerequisites:**
+- Docker running
+- Vespa configuration files in `vespa/` directory
+
 ## PubSub Management Scripts
 
 ### Local Development: `pubsub-manager.sh`

--- a/services/demos/README_vespa.md
+++ b/services/demos/README_vespa.md
@@ -10,26 +10,32 @@ This directory contains comprehensive demonstration services for the Vespa-power
 # 1. Start all services with human-readable logging
 ./scripts/start-dev-logs.sh
 
-# 2. Clear existing data from Vespa
+# 2. Start Vespa, deploy app, and show status (single command!)
+./scripts/vespa.sh
+
+# 3. Clear existing data from Vespa
 ./scripts/vespa.sh --clear-data --email {email} --env-file {env_file} --force
 
-# 3. Backfill with fresh data
+# 4. Backfill with fresh data
 python services/demos/vespa_backfill.py
 
-# 4. Search and dump results
+# 5. Search and dump results
 python services/demos/vespa_search.py {email} --dump
 ```
 
 
 **Quick Reference:**
 ```bash
-# Check status and auto-start if needed
+# Start container, deploy app, and show status (recommended - does everything!)
 ./scripts/vespa.sh
 
-# Start all services
+# Same as above (explicit auto mode)
+./scripts/vespa.sh --auto
+
+# Start container only
 ./scripts/vespa.sh --start
 
-# Deploy Briefly application
+# Deploy application only
 ./scripts/vespa.sh --deploy
 
 # Show status
@@ -49,6 +55,8 @@ python services/demos/vespa_search.py {email} --dump
 ```
 
 **Note**: Replace `{email}` with actual email address and `{env_file}` with path to environment file containing API keys.
+
+**🚀 Key Improvement**: The `vespa.sh` script now requires only **one invocation** instead of the previous two-step process. It automatically starts the container and deploys the application if needed!
 
 ## Demo Scripts
 
@@ -326,31 +334,56 @@ The new `./scripts/vespa.sh` script consolidates all Vespa management functional
 - 📦 **Briefly deployment**: Properly deploys your `vespa/services.xml`, `vespa/hosts.xml`, and `vespa/schemas/` configuration
 - 📊 **Real-time monitoring**: Live log monitoring during deployment
 - 🛠️ **Comprehensive management**: Start, stop, deploy, status, restart, cleanup operations
+- ⚡ **One-invocation setup**: No more separate `--start` and `--deploy` calls!
 
 The `vespa.sh` script manages all Vespa services in one place:
 
 ```bash
-# Start all Vespa services (Vespa Engine, Loader Service, Query Service)
-./scripts/vespa.sh --start
+# 🚀 NEW: Start container, deploy app, and show status (single command!)
+./scripts/vespa.sh
 
-# Check status
-./scripts/vespa.sh --status
+# Same as above (explicit auto mode)
+./scripts/vespa.sh --auto
 
-# Stop all services
-./scripts/vespa.sh --stop
-
-# Clean up container
-./scripts/vespa.sh --cleanup
-
-# Restart all services
-./scripts/vespa.sh --restart
-
-# Deploy Briefly application to Vespa
-./scripts/vespa.sh --deploy
+# Individual operations (for specific needs)
+./scripts/vespa.sh --start      # Start container only
+./scripts/vespa.sh --deploy     # Deploy application only
+./scripts/vespa.sh --status     # Show status
+./scripts/vespa.sh --stop       # Stop all services
+./scripts/vespa.sh --restart    # Restart all services
+./scripts/vespa.sh --cleanup    # Clean up container
 ```
+
+**🚀 Major Improvement**: The script now automatically detects what needs to be done and handles it in the correct order. If you run it without arguments, it will:
+1. Start the Vespa container if it's not running
+2. Deploy the Briefly application if it's not deployed
+3. Show the final status
+
+This eliminates the previous two-step process where you had to run `--start` first, then `--deploy` separately.
 
 **Note**: The Pub/Sub emulator is managed separately by `scripts/local-pubsub.sh` to avoid conflicts and provide better isolation.
 
+### Migration from Old Two-Step Process
+
+**Before (required 2 invocations):**
+```bash
+./scripts/vespa.sh --start    # First: start container
+./scripts/vespa.sh --deploy   # Second: deploy application
+```
+
+**Now (single invocation):**
+```bash
+./scripts/vespa.sh            # Does everything automatically
+# or
+./scripts/vespa.sh --auto     # Same as above
+```
+
+**What Changed:**
+- ✅ **Single command setup** - No more separate `--start` and `--deploy` calls
+- ✅ **Smart detection** - Automatically detects what needs to be done
+- ✅ **Proper sequencing** - Ensures container is ready before deploying
+- ✅ **Status confirmation** - Always shows final status for verification
+- ✅ **Backward compatibility** - All existing flags still work for specific operations
 
 ### Option 3: Start Services Individually
 
@@ -395,9 +428,12 @@ python -m uvicorn main:app --host 0.0.0.0 --port 8006 --reload
 The full Vespa demo workflow involves both infrastructure management and data operations:
 
 1. **Start Services**: `./scripts/start-dev-logs.sh` - Start all services with human-readable logging
-2. **Clear Data**: `./scripts/vespa.sh --clear-data --email {email} --env-file {env_file}` - Clear existing data from Vespa
-3. **Backfill Data**: `python services/demos/vespa_backfill.py` - Populate Vespa with fresh data
-4. **Search & Dump**: `python services/demos/vespa_search.py {email} --dump` - Search and dump all content for the user
+2. **🚀 Setup Vespa**: `./scripts/vespa.sh` - **Single command** that starts container, deploys app, and shows status
+3. **Clear Data**: `./scripts/vespa.sh --clear-data --email {email} --env-file {env_file}` - Clear existing data from Vespa
+4. **Backfill Data**: `python services/demos/vespa_backfill.py` - Populate Vespa with fresh data
+5. **Search & Dump**: `python services/demos/vespa_search.py {email} --dump` - Search and dump all content for the user
+
+**🚀 Key Improvement**: Step 2 now requires only **one command** instead of the previous two-step process!
 
 ### Individual Demo Scripts
 1. **First time setup**: Run `vespa_backfill.py` once to populate Vespa with data


### PR DESCRIPTION
Simplifies to one call vs. --start and --deploy calls

- Modified vespa.sh default behavior to automatically start container and deploy app
- Added --auto flag for explicit single-invocation mode
- Updated scripts/README.md with Vespa management documentation
- Updated services/demos/README_vespa.md with new single-command workflow
- Maintains backward compatibility with all existing flags
- Improves user experience by eliminating two-step setup process