### PR TITLE
refactor: Replace deprecated datetime.utcnow() with datetime.now

### DIFF
--- a/services/meetings/services/audit_logger.py
+++ b/services/meetings/services/audit_logger.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, Dict, Optional
 
@@ -67,7 +67,7 @@ class AuditLogger:
             severity: Log level (INFO, WARNING, ERROR)
         """
         audit_entry = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(UTC).isoformat(),
             "event_type": event_type.value,
             "user_id": user_id,
             "resource_id": resource_id,

--- a/services/vespa_query/main.py
+++ b/services/vespa_query/main.py
@@ -4,7 +4,7 @@ Vespa Query Service - Query interface for hybrid search capabilities
 """
 
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 import uvicorn
@@ -140,7 +140,7 @@ async def health_check() -> Dict[str, Any]:
     health_status: Dict[str, Any] = {
         "status": "healthy",
         "service": "vespa-query",
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
         "checks": {},
     }
 


### PR DESCRIPTION
This commit fixes the DeprecationWarning for `datetime.datetime.utcnow()` by replacing it with the recommended timezone-aware `datetime.datetime.now(datetime.UTC)`.

Changes were applied to:
- services/meetings/services/audit_logger.py
- services/vespa_query/main.py