### PR TITLE
refactor: httpx deprecation warning and runtime warning

### DIFF
--- a/services/shipments/tests/test_email_parser_api.py
+++ b/services/shipments/tests/test_email_parser_api.py
@@ -353,7 +353,7 @@ class TestEmailParserAPI:
         """Test handling of malformed JSON."""
         response = client.post(
             "/v1/shipments/events/from-email",
-            data="invalid json",
+            content="invalid json",
             headers={"Content-Type": "application/json"},
         )
 

--- a/services/user/integrations/oauth_config.py
+++ b/services/user/integrations/oauth_config.py
@@ -646,9 +646,11 @@ class OAuthConfig:
                 headers["X-Request-Id"] = request_id
 
             async with httpx.AsyncClient() as client:
+                # Manually encode data to prevent httpx deprecation warning with respx
+                encoded_params = urllib.parse.urlencode(token_params).encode("utf-8")
                 response = await client.post(
                     provider_config.token_url,
-                    data=token_params,
+                    content=encoded_params,
                     headers=headers,
                     timeout=30.0,
                 )
@@ -711,9 +713,11 @@ class OAuthConfig:
                 headers["X-Request-Id"] = request_id
 
             async with httpx.AsyncClient() as client:
+                # Manually encode data to prevent httpx deprecation warning with respx
+                encoded_params = urllib.parse.urlencode(refresh_params).encode("utf-8")
                 response = await client.post(
                     provider_config.token_url,
-                    data=refresh_params,
+                    content=encoded_params,
                     headers=headers,
                     timeout=30.0,
                 )
@@ -821,9 +825,11 @@ class OAuthConfig:
                 headers["X-Request-Id"] = request_id
 
             async with httpx.AsyncClient() as client:
+                # Manually encode data to prevent httpx deprecation warning with respx
+                encoded_params = urllib.parse.urlencode(revoke_params).encode("utf-8")
                 response = await client.post(
                     provider_config.revoke_url,
-                    data=revoke_params,
+                    content=encoded_params,
                     headers=headers,
                     timeout=30.0,
                 )

--- a/services/user/tests/test_oauth_config.py
+++ b/services/user/tests/test_oauth_config.py
@@ -721,7 +721,11 @@ class TestOAuthConfig(BaseUserManagementTest):
 
             # Check the URL and data
             assert actual_call[0][0] == expected_token_url
-            assert actual_call[1]["data"] == expected_payload
+            # Verify that the content is a URL-encoded string matching the payload
+            actual_payload = urllib.parse.parse_qs(actual_call[1]["content"].decode("utf-8"))
+            # parse_qs returns lists for values, so we need to adjust the expected payload
+            expected_payload_qs = {k: [v] for k, v in expected_payload.items()}
+            assert actual_payload == expected_payload_qs
             assert actual_call[1]["timeout"] == 30.0
 
             # Check headers - should include Content-Type and may include X-Request-Id
@@ -777,7 +781,11 @@ class TestOAuthConfig(BaseUserManagementTest):
 
             # Check the URL and data
             assert actual_call[0][0] == expected_token_url
-            assert actual_call[1]["data"] == expected_payload
+            # Verify that the content is a URL-encoded string matching the payload
+            actual_payload = urllib.parse.parse_qs(actual_call[1]["content"].decode("utf-8"))
+            # parse_qs returns lists for values, so we need to adjust the expected payload
+            expected_payload_qs = {k: [v] for k, v in expected_payload.items()}
+            assert actual_payload == expected_payload_qs
             assert actual_call[1]["timeout"] == 30.0
 
             # Check headers - should include Content-Type and may include X-Request-Id
@@ -849,7 +857,11 @@ class TestOAuthConfig(BaseUserManagementTest):
 
             # Check the URL and data
             assert actual_call[0][0] == expected_token_url
-            assert actual_call[1]["data"] == expected_payload
+            # Verify that the content is a URL-encoded string matching the payload
+            actual_payload = urllib.parse.parse_qs(actual_call[1]["content"].decode("utf-8"))
+            # parse_qs returns lists for values, so we need to adjust the expected payload
+            expected_payload_qs = {k: [v] for k, v in expected_payload.items()}
+            assert actual_payload == expected_payload_qs
             assert actual_call[1]["timeout"] == 30.0
 
             # Check headers - should include Content-Type and may include X-Request-Id

--- a/services/user/tests/test_oauth_config.py
+++ b/services/user/tests/test_oauth_config.py
@@ -722,7 +722,9 @@ class TestOAuthConfig(BaseUserManagementTest):
             # Check the URL and data
             assert actual_call[0][0] == expected_token_url
             # Verify that the content is a URL-encoded string matching the payload
-            actual_payload = urllib.parse.parse_qs(actual_call[1]["content"].decode("utf-8"))
+            actual_payload = urllib.parse.parse_qs(
+                actual_call[1]["content"].decode("utf-8")
+            )
             # parse_qs returns lists for values, so we need to adjust the expected payload
             expected_payload_qs = {k: [v] for k, v in expected_payload.items()}
             assert actual_payload == expected_payload_qs
@@ -782,7 +784,9 @@ class TestOAuthConfig(BaseUserManagementTest):
             # Check the URL and data
             assert actual_call[0][0] == expected_token_url
             # Verify that the content is a URL-encoded string matching the payload
-            actual_payload = urllib.parse.parse_qs(actual_call[1]["content"].decode("utf-8"))
+            actual_payload = urllib.parse.parse_qs(
+                actual_call[1]["content"].decode("utf-8")
+            )
             # parse_qs returns lists for values, so we need to adjust the expected payload
             expected_payload_qs = {k: [v] for k, v in expected_payload.items()}
             assert actual_payload == expected_payload_qs
@@ -858,7 +862,9 @@ class TestOAuthConfig(BaseUserManagementTest):
             # Check the URL and data
             assert actual_call[0][0] == expected_token_url
             # Verify that the content is a URL-encoded string matching the payload
-            actual_payload = urllib.parse.parse_qs(actual_call[1]["content"].decode("utf-8"))
+            actual_payload = urllib.parse.parse_qs(
+                actual_call[1]["content"].decode("utf-8")
+            )
             # parse_qs returns lists for values, so we need to adjust the expected payload
             expected_payload_qs = {k: [v] for k, v in expected_payload.items()}
             assert actual_payload == expected_payload_qs

--- a/services/user/tests/test_refresh_deduplication.py
+++ b/services/user/tests/test_refresh_deduplication.py
@@ -4,7 +4,7 @@ Test refresh deduplication to ensure it doesn't cause upstream failures.
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -19,6 +19,7 @@ class TestRefreshDeduplication(BaseUserManagementIntegrationTest):
     def _setup_mock_session(self):
         """Helper to set up a properly mocked database session."""
         mock_session_instance = AsyncMock()
+        mock_session_instance.add = MagicMock()  # Mock session.add as synchronous
         mock_session_instance.__aenter__ = AsyncMock(return_value=mock_session_instance)
         mock_session_instance.__aexit__ = AsyncMock(return_value=None)
         return mock_session_instance

--- a/services/user/tests/test_token_optimization.py
+++ b/services/user/tests/test_token_optimization.py
@@ -7,7 +7,7 @@ redundant token requests and refresh operations.
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -165,6 +165,7 @@ class TestTokenOptimization(BaseUserManagementTest):
             "services.user.services.integration_service.get_async_session"
         ) as mock_session:
             mock_session_instance = AsyncMock()
+            mock_session_instance.add = MagicMock()  # Mock session.add as synchronous
             mock_session_instance.__aenter__ = AsyncMock(
                 return_value=mock_session_instance
             )


### PR DESCRIPTION
- Fixes a `DeprecationWarning` from `httpx` when sending form data in tests. The `data` parameter was being misinterpreted as raw bytes/text. The fix is to manually encode the form data and use the `content` parameter instead.

- Fixes a `RuntimeWarning` about an un-awaited coroutine in the tests for `IntegrationService`. The warning was caused by a database session mock that was incorrectly configured as an `AsyncMock`. The fix is to explicitly mock `session.add` as a synchronous `MagicMock`.