### PR TITLE
fix(chat): prevent agent from seeing duplicate messages

### DIFF
--- a/services/chat/agents/briefly_agent.py
+++ b/services/chat/agents/briefly_agent.py
@@ -290,18 +290,26 @@ class BrieflyAgent(FunctionAgent):
                 {"stream_events": lambda: self._fallback_stream_events(user_msg)},
             )()
 
-    async def _load_conversation_history(self) -> None:
+    async def _load_conversation_history(self, exclude_latest: bool = True) -> None:
         """Load conversation history from database into agent context."""
         try:
             from services.chat import history_manager
 
-            # Get messages from database
+            # Get messages from database (get extra to account for exclusion)
             db_messages = await history_manager.get_thread_history(
-                int(self._thread_id), limit=100
+                int(self._thread_id), limit=101 if exclude_latest else 100
             )
 
             # Reverse to chronological order (oldest to newest)
             db_messages = list(reversed(db_messages))
+
+            # Exclude the most recent message if requested (it's likely the current user input)
+            if (
+                exclude_latest
+                and db_messages
+                and db_messages[-1].user_id == self._user_id
+            ):
+                db_messages = db_messages[:-1]
 
             # Convert to context format
             chat_history = []
@@ -427,8 +435,8 @@ class BrieflyAgent(FunctionAgent):
     async def astream_chat(self, message: str) -> Any:
         """Async streaming chat method for compatibility with API usage."""
         try:
-            # Load conversation history before streaming chat
-            await self._load_conversation_history()
+            # Load conversation history before streaming chat (exclude latest to avoid duplication)
+            await self._load_conversation_history(exclude_latest=True)
 
             try:
                 history_len = len(

--- a/services/chat/tests/test_briefly_agent_context.py
+++ b/services/chat/tests/test_briefly_agent_context.py
@@ -119,8 +119,9 @@ class TestBrieflyAgentContext:
                 # Test that conversation history is loaded
                 # The agent should have loaded the conversation history during achat
                 # We can verify this by checking if the history manager was called
+                # Note: limit=101 is used when exclude_latest=True to account for excluding the latest message
                 mock_history_manager.get_thread_history.assert_called_once_with(
-                    123, limit=100
+                    123, limit=101
                 )
 
     @pytest.mark.asyncio
@@ -355,8 +356,9 @@ class TestBrieflyAgentContext:
                 mock_run.assert_called_once()
 
                 # Verify that the rich history was loaded during the achat call
+                # Note: limit=101 is used when exclude_latest=True to account for excluding the latest message
                 mock_history_manager.get_thread_history.assert_called_once_with(
-                    123, limit=100
+                    123, limit=101
                 )
 
 


### PR DESCRIPTION
- User message was being saved to DB before agent processing
- Agent would then load ALL history including the current message
- This caused the 'you asked twice' behavior on new threads
- Now exclude the latest user message when loading conversation history