### PR TITLE
fix(be): Restore timezone support to Briefly agent with localized datetime prompts

### DIFF
--- a/services/chat/agents/briefly_agent.py
+++ b/services/chat/agents/briefly_agent.py
@@ -100,7 +100,7 @@ class BrieflyAgent(FunctionAgent):
 
         # Generate fresh date/time each time for current context
         now_utc = datetime.utcnow()
-        user_tz = getattr(self, '_user_timezone', None)
+        user_tz = getattr(self, "_user_timezone", None)
         if user_tz:
             try:
                 tz = pytz.timezone(user_tz)
@@ -130,12 +130,12 @@ class BrieflyAgent(FunctionAgent):
         """Get thread-specific draft context for enhanced awareness."""
         try:
             # Create DraftTools instance to access draft data
-            user_id = getattr(self, '_user_id', None)
-            thread_id = getattr(self, '_thread_id', None)
-            
+            user_id = getattr(self, "_user_id", None)
+            thread_id = getattr(self, "_thread_id", None)
+
             if not user_id or not thread_id:
                 return ""
-                
+
             draft_tools = DraftTools(user_id)
 
             # Get existing drafts for this thread
@@ -289,7 +289,7 @@ class BrieflyAgent(FunctionAgent):
     @property
     def thread_id(self) -> str:
         """Get the thread ID for API compatibility."""
-        return getattr(self, '_thread_id', None)
+        return getattr(self, "_thread_id", None)
 
     def get_current_system_prompt(self) -> str:
         """Get the current system prompt with fresh context."""

--- a/services/chat/agents/briefly_agent.py
+++ b/services/chat/agents/briefly_agent.py
@@ -100,10 +100,9 @@ class BrieflyAgent(FunctionAgent):
 
         # Generate fresh date/time each time for current context
         now_utc = datetime.utcnow()
-        user_tz = getattr(self, "_user_timezone", None)
-        if user_tz:
+        if self._user_timezone:
             try:
-                tz = pytz.timezone(user_tz)
+                tz = pytz.timezone(self._user_timezone)
                 now_local = pytz.utc.localize(now_utc).astimezone(tz)
             except Exception:
                 now_local = now_utc
@@ -130,16 +129,10 @@ class BrieflyAgent(FunctionAgent):
         """Get thread-specific draft context for enhanced awareness."""
         try:
             # Create DraftTools instance to access draft data
-            user_id = getattr(self, "_user_id", None)
-            thread_id = getattr(self, "_thread_id", None)
-
-            if not user_id or not thread_id:
-                return ""
-
-            draft_tools = DraftTools(user_id)
+            draft_tools = DraftTools(self._user_id)
 
             # Get existing drafts for this thread
-            drafts = draft_tools.get_draft_data(thread_id)
+            drafts = draft_tools.get_draft_data(self._thread_id)
 
             if not drafts:
                 return ""
@@ -289,7 +282,7 @@ class BrieflyAgent(FunctionAgent):
     @property
     def thread_id(self) -> str:
         """Get the thread ID for API compatibility."""
-        return getattr(self, "_thread_id", None)
+        return self._thread_id
 
     def get_current_system_prompt(self) -> str:
         """Get the current system prompt with fresh context."""

--- a/services/chat/agents/briefly_agent.py
+++ b/services/chat/agents/briefly_agent.py
@@ -190,6 +190,13 @@ class BrieflyAgent(FunctionAgent):
             model=llm_model, provider=llm_provider, **llm_kwargs
         )
 
+        # Store additional components we need first
+        self._user_timezone = user_timezone or "UTC"
+        self._thread_id = str(thread_id)
+        self._user_id = user_id
+        self._vespa_endpoint = vespa_endpoint
+        self._tool_catalog = tool_catalog
+
         # Create base system prompt without dynamic context (will be added dynamically)
         base_system_prompt = (
             "You are Briefly, a single-agent assistant with comprehensive tools.\n\n"
@@ -239,11 +246,6 @@ class BrieflyAgent(FunctionAgent):
 
         # Keep a reference to tools that manage external resources
         self._search_tools: Optional[UserDataSearchTool] = search_tools
-        self._thread_id = str(thread_id)
-        self._user_id = user_id
-        self._vespa_endpoint = vespa_endpoint
-        self._tool_catalog = tool_catalog
-        self._user_timezone = user_timezone or "UTC"
 
         # Initialize simple state management instead of problematic Context
         self._state: dict[str, Any] = {}

--- a/services/chat/api.py
+++ b/services/chat/api.py
@@ -126,6 +126,7 @@ async def chat_endpoint(
         thread_id=int(thread.id),
         user_id=user_id,
         vespa_endpoint=get_settings().vespa_endpoint,
+        user_timezone=user_timezone,
         llm_model=get_settings().llm_model,
         llm_provider=get_settings().llm_provider,
         **get_settings().llm_kwargs if hasattr(get_settings(), "llm_kwargs") else {},
@@ -284,6 +285,7 @@ async def chat_stream_endpoint(
                 thread_id=int(thread.id),
                 user_id=user_id,
                 vespa_endpoint=get_settings().vespa_endpoint,
+                user_timezone=user_timezone,
                 llm_model=get_settings().llm_model,
                 llm_provider=get_settings().llm_provider,
                 **(


### PR DESCRIPTION
- Add user_timezone parameter to BrieflyAgent and create_briefly_agent
- Localize _create_context_aware_prompt to user's timezone using pytz
- Pass timezone from chat API endpoints through to agent
- Display current date/time in user's local timezone in system prompt
- Fallback to UTC if timezone unavailable or pytz import fails