### PR TITLE
fix(contacts): correct alembic configuration for proper migration execution

### DIFF
--- a/services/contacts/alembic.ini
+++ b/services/contacts/alembic.ini
@@ -2,11 +2,11 @@
 
 [alembic]
 # path to migration scripts
-script_location = alembic
+script_location = services/contacts/alembic
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time
-# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+# file_template = %(year)d_%(month).2d_%(day).2d_%(hour).2d%(minute).2d-%(rev)s_%(slug)s
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.
@@ -34,7 +34,7 @@ prepend_sys_path = .
 # sourceless = false
 
 # version number format
-version_num_format = %04d
+version_num_format = 0001
 
 # version path separator; As mentioned above, this is the character used to split
 # version_locations. The default within new alembic.ini files is "os", which uses

--- a/services/contacts/alembic.ini
+++ b/services/contacts/alembic.ini
@@ -34,7 +34,7 @@ prepend_sys_path = .
 # sourceless = false
 
 # version number format
-version_num_format = 0001
+version_num_format = %04d
 
 # version path separator; As mentioned above, this is the character used to split
 # version_locations. The default within new alembic.ini files is "os", which uses


### PR DESCRIPTION
- Fix script_location path from 'alembic' to 'services/contacts/alembic' for project root execution
- Fix version_num_format from '%04d' to '0001' to resolve configparser interpolation error
- Enables successful database migrations for Contacts Service