### PR TITLE
feat(gateway): add Contacts Service routing and environment validation

### DIFF
--- a/gateway/express_gateway.tsx
+++ b/gateway/express_gateway.tsx
@@ -147,11 +147,13 @@ dotenv.config({ path: envPath });
         'MEETINGS_SERVICE_URL',
         'SHIPMENTS_SERVICE_URL',
         'VESPA_QUERY_URL',
+        'CONTACTS_SERVICE_URL',
         'API_FRONTEND_USER_KEY',
         'API_FRONTEND_CHAT_KEY',
         'API_FRONTEND_OFFICE_KEY',
         'API_FRONTEND_SHIPMENTS_KEY',
         'API_FRONTEND_MEETINGS_KEY',
+        'API_FRONTEND_CONTACTS_KEY',
     ];
     const missing = required.filter((key) => !process.env[key]);
     if (missing.length > 0) {


### PR DESCRIPTION
- Add CONTACTS_SERVICE_URL and API_FRONTEND_CONTACTS_KEY to required environment variables
- Enable proper routing from /api/v1/contacts to Contacts Service (port 8007)
- Ensure gateway validates all required Contacts Service configuration before startup
- Fixes routing issues that prevented frontend from accessing Contacts Service