### PR TITLE
fix(be): standardize contacts logging

### DIFF
--- a/services/contacts/services/contact_discovery_consumer.py
+++ b/services/contacts/services/contact_discovery_consumer.py
@@ -6,7 +6,6 @@ for database persistence in the Contacts Service.
 """
 
 import json
-import logging
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 try:
@@ -31,10 +30,11 @@ from services.common.events import (
     EmailEvent,
     TodoEvent,
 )
+from services.common.logging_config import get_logger
 from services.common.pubsub_client import PubSubClient
 from services.contacts.services.contact_discovery_service import ContactDiscoveryService
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ContactDiscoveryConsumer:

--- a/services/contacts/services/contact_discovery_service.py
+++ b/services/contacts/services/contact_discovery_service.py
@@ -5,7 +5,6 @@ Moved from services/user/services/contact_discovery_service.py and adapted
 for database persistence in the Contacts Service.
 """
 
-import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set
 from uuid import uuid4
@@ -22,11 +21,12 @@ from services.common.events import (
     TodoEvent,
 )
 from services.common.events.todo_events import TodoData, TodoEvent
+from services.common.logging_config import get_logger
 from services.common.pubsub_client import PubSubClient
 from services.contacts.models.contact import Contact
 from services.contacts.schemas.contact import EmailContactUpdate
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ContactDiscoveryService:

--- a/services/contacts/services/contact_service.py
+++ b/services/contacts/services/contact_service.py
@@ -4,7 +4,6 @@ Contact service for business logic operations on contacts.
 Provides CRUD operations, search, filtering, and statistics for contacts.
 """
 
-import logging
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import and_, desc, func, or_, select
@@ -12,10 +11,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select as sqlmodel_select
 
 from services.common.http_errors import NotFoundError, ValidationError
+from services.common.logging_config import get_logger
 from services.contacts.models.contact import Contact
 from services.contacts.schemas.contact import ContactCreate, EmailContactUpdate
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ContactService:


### PR DESCRIPTION
- Replace standard Python logging with get_logger from services.common.logging_config
- Fix contact_service.py, contact_discovery_consumer.py, and contact_discovery_service.py
- Ensures all Contacts Service logs use consistent structured format with request ID, user context, and service name