### PR TITLE
fix(contacts): resolve auto-increment primary key issue

### DIFF
--- a/frontend/types/api/contacts/models/Contact.ts
+++ b/frontend/types/api/contacts/models/Contact.ts
@@ -10,7 +10,7 @@ export type Contact = {
     /**
      * Unique contact ID
      */
-    id?: (string | null);
+    id?: (number | null);
     /**
      * User ID who owns this contact
      */

--- a/services/contacts/alembic/versions/6e6ed8afcfd9_create_contacts_table.py
+++ b/services/contacts/alembic/versions/6e6ed8afcfd9_create_contacts_table.py
@@ -20,7 +20,7 @@ def upgrade() -> None:
     # Create contacts table
     op.create_table(
         "contacts",
-        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
         sa.Column("user_id", sa.String(), nullable=False),
         sa.Column("email_address", sa.String(), nullable=False),
         sa.Column("display_name", sa.String(), nullable=True),

--- a/services/contacts/models/contact.py
+++ b/services/contacts/models/contact.py
@@ -32,7 +32,7 @@ class Contact(SQLModel, table=True):
 
     __tablename__ = "contacts"  # type: ignore[assignment]
 
-    id: Optional[str] = Field(
+    id: Optional[int] = Field(
         default=None, primary_key=True, description="Unique contact ID"
     )
     user_id: str = Field(..., description="User ID who owns this contact")

--- a/services/contacts/services/contact_discovery_service.py
+++ b/services/contacts/services/contact_discovery_service.py
@@ -560,13 +560,13 @@ class ContactDiscoveryService:
             from services.common.events.contact_events import ContactData, ContactEvent
 
             contact_data = ContactData(
-                id=contact.id or str(uuid4()),
+                id=str(contact.id) if contact.id else str(uuid4()),
                 display_name=contact.display_name or contact.email_address,
                 given_name=contact.given_name,
                 family_name=contact.family_name,
                 email_addresses=[contact.email_address],
                 provider="contact_discovery",
-                provider_contact_id=contact.id or str(uuid4()),
+                provider_contact_id=str(contact.id) if contact.id else str(uuid4()),
                 notes=contact.notes,
                 last_modified=contact.updated_at,
             )


### PR DESCRIPTION
- Change Contact model id field from Optional[str] to Optional[int] to enable auto-increment
- Update migration to use sa.Integer() with autoincrement=True for id column
- Reset database and re-run migration to apply corrected schema
- Maintains consistency with other services' primary key patterns

Fixes the 'null value in column id violates not-null constraint' error