### PR TITLE
refactor(office): add "office" to api prefix

### DIFF
--- a/documentation/microsoft-email-threading-implementation.md
+++ b/documentation/microsoft-email-threading-implementation.md
@@ -21,9 +21,12 @@ The `MicrosoftAPIClient` class has been extended with new methods for thread-awa
 
 New REST API endpoints for thread operations:
 
-- `GET /api/v1/email/threads` - Get email threads from multiple providers
-- `GET /api/v1/email/threads/{thread_id}` - Get a specific thread with all messages
-- `GET /api/v1/email/messages/{message_id}/thread` - Get thread containing a specific message
+- `GET /api/v1/email/threads` - Get email threads from multiple providers (legacy path)
+- `GET /api/v1/office/email/threads` - Get email threads from multiple providers (new path)
+- `GET /api/v1/email/threads/{thread_id}` - Get a specific thread with all messages (legacy path)
+- `GET /api/v1/office/email/threads/{thread_id}` - Get a specific thread with all messages (new path)
+- `GET /api/v1/email/messages/{message_id}/thread` - Get thread containing a specific message (legacy path)
+- `GET /api/v1/office/email/messages/{message_id}/thread` - Get thread containing a specific message (new path)
 
 #### 3. Thread Normalization (`services/office/core/normalizer.py`)
 
@@ -70,8 +73,14 @@ Custom React hook for managing thread state:
 
 ### Get Email Threads
 
+**Legacy Path:**
 ```http
 GET /api/v1/email/threads
+```
+
+**New Path:**
+```http
+GET /api/v1/office/email/threads
 ```
 
 **Query Parameters:**
@@ -113,8 +122,14 @@ GET /api/v1/email/threads
 
 ### Get Specific Thread
 
+**Legacy Path:**
 ```http
 GET /api/v1/email/threads/{thread_id}
+```
+
+**New Path:**
+```http
+GET /api/v1/office/email/threads/{thread_id}
 ```
 
 **Path Parameters:**
@@ -158,8 +173,14 @@ GET /api/v1/email/threads/{thread_id}
 
 ### Get Message Thread
 
+**Legacy Path:**
 ```http
 GET /api/v1/email/messages/{message_id}/thread
+```
+
+**New Path:**
+```http
+GET /api/v1/office/email/messages/{message_id}/thread
 ```
 
 **Path Parameters:**

--- a/frontend/api/clients/office-client.ts
+++ b/frontend/api/clients/office-client.ts
@@ -43,7 +43,7 @@ export class OfficeClient extends GatewayClient {
         params.append('time_zone', time_zone);
         if (noCache) params.append('no_cache', 'true');
 
-        return this.request<TypedApiResponse_List_CalendarEvent__>(`/api/v1/calendar/events?${params.toString()}`);
+        return this.request<TypedApiResponse_List_CalendarEvent__>(`/api/v1/office/calendar/events?${params.toString()}`);
     }
 
     async createCalendarEvent(payload: CreateCalendarEventRequest) {
@@ -57,7 +57,7 @@ export class OfficeClient extends GatewayClient {
         const params = new URLSearchParams();
         params.append('user_id', userId);
 
-        return this.request<TypedApiResponse_CalendarEventResponse_>(`/api/v1/calendar/events?${params.toString()}`, {
+        return this.request<TypedApiResponse_CalendarEventResponse_>(`/api/v1/office/calendar/events?${params.toString()}`, {
             method: 'POST',
             body: payload,
         });
@@ -74,7 +74,7 @@ export class OfficeClient extends GatewayClient {
         const params = new URLSearchParams();
         params.append('user_id', userId);
 
-        return this.request<TypedApiResponse_CalendarEventResponse_>(`/api/v1/calendar/events/${encodeURIComponent(eventId)}?${params.toString()}`, {
+        return this.request<TypedApiResponse_CalendarEventResponse_>(`/api/v1/office/calendar/events/${encodeURIComponent(eventId)}?${params.toString()}`, {
             method: 'PUT',
             body: payload,
         });
@@ -91,7 +91,7 @@ export class OfficeClient extends GatewayClient {
         const params = new URLSearchParams();
         params.append('user_id', userId);
 
-        return this.request<TypedApiResponse_CalendarEventResponse_>(`/api/v1/calendar/events/${encodeURIComponent(eventId)}?${params.toString()}`, {
+        return this.request<TypedApiResponse_CalendarEventResponse_>(`/api/v1/office/calendar/events/${encodeURIComponent(eventId)}?${params.toString()}`, {
             method: 'DELETE',
         });
     }
@@ -115,7 +115,7 @@ export class OfficeClient extends GatewayClient {
         if (labels) labels.forEach(label => params.append('labels', label));
         if (folderId) params.append('folder_id', folderId);
 
-        return this.request<EmailMessageList>(`/api/v1/email/messages?${params.toString()}`);
+        return this.request<EmailMessageList>(`/api/v1/office/email/messages?${params.toString()}`);
     }
 
     async getThreads(
@@ -139,7 +139,7 @@ export class OfficeClient extends GatewayClient {
         if (pageToken) params.append('page_token', pageToken);
         if (noCache) params.append('no_cache', 'true');
 
-        return this.request<EmailThreadList>(`/api/v1/email/threads?${params.toString()}`);
+        return this.request<EmailThreadList>(`/api/v1/office/email/threads?${params.toString()}`);
     }
 
     async getThread(
@@ -152,7 +152,7 @@ export class OfficeClient extends GatewayClient {
         if (includeBody) params.append('include_body', 'true');
         if (noCache) params.append('no_cache', 'true');
 
-        return this.request<EmailThreadList>(`/api/v1/email/threads/${threadId}?${params.toString()}`);
+        return this.request<EmailThreadList>(`/api/v1/office/email/threads/${threadId}?${params.toString()}`);
     }
 
     // Provider Email Drafts (Office Service)
@@ -167,7 +167,7 @@ export class OfficeClient extends GatewayClient {
         reply_to_message_id?: string;
         provider?: 'google' | 'microsoft';
     }): Promise<EmailDraftResponse> {
-        return this.request<EmailDraftResponse>(`/api/v1/email/drafts`, {
+        return this.request<EmailDraftResponse>(`/api/v1/office/email/drafts`, {
             method: 'POST',
             body: {
                 action: payload.action || 'new',
@@ -191,7 +191,7 @@ export class OfficeClient extends GatewayClient {
         body?: string;
         provider: 'google' | 'microsoft';
     }): Promise<EmailDraftResponse> {
-        return this.request<EmailDraftResponse>(`/api/v1/email/drafts/${draftId}`, {
+        return this.request<EmailDraftResponse>(`/api/v1/office/email/drafts/${draftId}`, {
             method: 'PUT',
             body: {
                 to: payload.to,
@@ -207,11 +207,11 @@ export class OfficeClient extends GatewayClient {
     async deleteEmailDraft(draftId: string, provider: 'google' | 'microsoft'): Promise<EmailDraftResponse> {
         const params = new URLSearchParams();
         params.append('provider', provider);
-        return this.request<EmailDraftResponse>(`/api/v1/email/drafts/${draftId}?${params.toString()}`, { method: 'DELETE' });
+        return this.request<EmailDraftResponse>(`/api/v1/office/email/drafts/${draftId}?${params.toString()}`, { method: 'DELETE' });
     }
 
     async listThreadDrafts(threadId: string): Promise<EmailDraftResponse> {
-        return this.request<EmailDraftResponse>(`/api/v1/email/threads/${threadId}/drafts`);
+        return this.request<EmailDraftResponse>(`/api/v1/office/email/threads/${threadId}/drafts`);
     }
 
     async getMessageThread(
@@ -224,7 +224,7 @@ export class OfficeClient extends GatewayClient {
         if (includeBody) params.append('include_body', 'true');
         if (noCache) params.append('no_cache', 'true');
 
-        return this.request<EmailThreadList>(`/api/v1/email/messages/${messageId}/thread?${params.toString()}`);
+        return this.request<EmailThreadList>(`/api/v1/office/email/messages/${messageId}/thread?${params.toString()}`);
     }
 
     // Bulk email operations
@@ -244,7 +244,7 @@ export class OfficeClient extends GatewayClient {
         };
         error?: string;
     }> {
-        return this.request('/api/v1/email/bulk-action', {
+        return this.request('/api/v1/office/email/bulk-action', {
             method: 'POST',
             body: {
                 action_type: actionType,
@@ -268,7 +268,7 @@ export class OfficeClient extends GatewayClient {
             });
         }
 
-        return this.request<EmailFolderList>(`/api/v1/email/folders?${params.toString()}`);
+        return this.request<EmailFolderList>(`/api/v1/office/email/folders?${params.toString()}`);
     }
 
     async getFiles(provider: string, path?: string) {
@@ -286,25 +286,25 @@ export class OfficeClient extends GatewayClient {
         if (q) params.append('q', q);
         if (company) params.append('company', company);
         if (noCache) params.append('no_cache', 'true');
-        return this.request<ContactList>(`/api/v1/contacts?${params.toString()}`);
+        return this.request<ContactList>(`/api/v1/office/contacts?${params.toString()}`);
     }
 
     async updateContact(contactId: string, payload: Partial<ContactList>): Promise<ContactUpdateResponse> {
-        return this.request<ContactUpdateResponse>(`/api/v1/contacts/${contactId}`, {
+        return this.request<ContactUpdateResponse>(`/api/v1/office/contacts/${contactId}`, {
             method: 'PUT',
             body: payload,
         });
     }
 
     async createContact(payload: Partial<ContactList> & { provider?: 'google' | 'microsoft' }): Promise<ContactCreateResponse> {
-        return this.request<ContactCreateResponse>(`/api/v1/contacts`, {
+        return this.request<ContactCreateResponse>(`/api/v1/office/contacts`, {
             method: 'POST',
             body: payload,
         });
     }
 
     async deleteContact(contactId: string): Promise<ContactDeleteResponse> {
-        return this.request<ContactDeleteResponse>(`/api/v1/contacts/${contactId}`, {
+        return this.request<ContactDeleteResponse>(`/api/v1/office/contacts/${contactId}`, {
             method: 'DELETE',
         });
     }
@@ -320,7 +320,7 @@ export class OfficeClient extends GatewayClient {
         provider?: 'google' | 'microsoft';
     }): Promise<{ success: boolean; messageId?: string; error?: string }> {
         try {
-            const result = await this.request<SendEmailResponse>('/api/v1/email/send', {
+            const result = await this.request<SendEmailResponse>('/api/v1/office/email/send', {
                 method: 'POST',
                 body: request,
             });

--- a/frontend/api/clients/office-client.ts
+++ b/frontend/api/clients/office-client.ts
@@ -1,3 +1,4 @@
+import { BulkActionType } from '@/types';
 import { getSession } from 'next-auth/react';
 import { getUserId } from '../../lib/session-utils';
 import type {
@@ -14,7 +15,6 @@ import type {
     TypedApiResponse_CalendarEventResponse_,
     TypedApiResponse_List_CalendarEvent__
 } from '../../types/api/office';
-import { BulkActionType } from '@/types';
 import { GatewayClient } from './gateway-client';
 
 export class OfficeClient extends GatewayClient {

--- a/gateway/express_gateway.tsx
+++ b/gateway/express_gateway.tsx
@@ -445,6 +445,9 @@ const serviceRoutes = {
     '/api/v1/email': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
     '/api/v1/files': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
     '/api/v1/contacts': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
+    '/api/v1/office/calendar': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
+    '/api/v1/office/email': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
+    '/api/v1/office/contacts': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
     '/api/v1/drafts': process.env.CHAT_SERVICE_URL || 'http://127.0.0.1:8002',
     '/api/v1/shipments': process.env.SHIPMENTS_SERVICE_URL || 'http://127.0.0.1:8004',
     '/api/v1/meetings': process.env.MEETINGS_SERVICE_URL || 'http://127.0.0.1:8005',
@@ -624,6 +627,14 @@ app.use('/api/v1/shipments/*', validateAuth, standardLimiter, createServiceProxy
 app.use('/api/v1/contacts', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/contacts'], { '^/api/v1/contacts': '/v1/contacts/' }));
 app.use('/api/v1/contacts/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/contacts'], { '^/api/v1/contacts': '/v1/contacts' }));
 
+// New office-prefixed routes
+app.use('/api/v1/office/calendar', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office/calendar'], { '^/api/v1/office/calendar': '/v1/calendar' }));
+app.use('/api/v1/office/calendar/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office/calendar'], { '^/api/v1/office/calendar': '/v1/calendar' }));
+app.use('/api/v1/office/email', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office/email'], { '^/api/v1/office/email': '/v1/email' }));
+app.use('/api/v1/office/email/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office/email'], { '^/api/v1/office/email': '/v1/email' }));
+app.use('/api/v1/office/contacts', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office/contacts'], { '^/api/v1/office/contacts': '/v1/contacts' }));
+app.use('/api/v1/office/contacts/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office/contacts'], { '^/api/v1/office/contacts': '/v1/contacts' }));
+
 // Catch-all for undefined routes
 app.use('*', (req, res) => {
     res.status(404).json({ error: 'Route not found' });
@@ -656,6 +667,9 @@ const server = app.listen(PORT, () => {
     logWithContext('info', `  /api/v1/email    → ${serviceRoutes['/api/v1/email']}`);
     logWithContext('info', `  /api/v1/files    → ${serviceRoutes['/api/v1/files']}`);
     logWithContext('info', `  /api/v1/contacts → ${serviceRoutes['/api/v1/contacts']}`);
+    logWithContext('info', `  /api/v1/office/calendar → ${serviceRoutes['/api/v1/office/calendar']}`);
+    logWithContext('info', `  /api/v1/office/email → ${serviceRoutes['/api/v1/office/email']}`);
+    logWithContext('info', `  /api/v1/office/contacts → ${serviceRoutes['/api/v1/office/contacts']}`);
     logWithContext('info', `  /api/v1/drafts     → ${serviceRoutes['/api/v1/drafts']}`);
     logWithContext('info', `  /api/v1/meetings → ${serviceRoutes['/api/v1/meetings']}`);
     logWithContext('info', `  /api/v1/bookings → ${serviceRoutes['/api/v1/bookings']}`);
@@ -675,7 +689,7 @@ server.on('upgrade', (request: any, socket: any, head: any) => {
 
     if (path.startsWith('/api/v1/chat')) {
         targetService = serviceRoutes['/api/v1/chat'];
-    } else if (path.startsWith('/api/v1/calendar') || path.startsWith('/api/v1/email') || path.startsWith('/api/v1/files') || path.startsWith('/api/v1/contacts')) {
+    } else if (path.startsWith('/api/v1/office/calendar') || path.startsWith('/api/v1/office/email') || path.startsWith('/api/v1/office/contacts') || path.startsWith('/api/v1/calendar') || path.startsWith('/api/v1/email') || path.startsWith('/api/v1/files') || path.startsWith('/api/v1/contacts')) {
         targetService = serviceRoutes['/api/v1/calendar'];
     } else if (path.startsWith('/api/v1/meetings')) {
         targetService = serviceRoutes['/api/v1/meetings'];

--- a/tasks/api-versioning-v1.md
+++ b/tasks/api-versioning-v1.md
@@ -212,9 +212,12 @@ If issues arise, the rollback plan is:
 ### Gateway Routes:
 - `/api/v1/users/*` → User Management Service
 - `/api/v1/chat/*` → Chat Service
-- `/api/v1/calendar/*` → Office Service
-- `/api/v1/email/*` → Office Service
+- `/api/v1/calendar/*` → Office Service (legacy)
+- `/api/v1/email/*` → Office Service (legacy)
 - `/api/v1/files/*` → Office Service
+- `/api/v1/office/calendar/*` → Office Service (new)
+- `/api/v1/office/email/*` → Office Service (new)
+- `/api/v1/office/contacts/*` → Office Service (new)
 - `/api/v1/drafts/*` → Chat Service
 - `/api/v1/meetings/*` → Meetings Service
 - `/api/v1/public/polls/*` → Meetings Service

--- a/tasks/office-api-path-prefix-update.md
+++ b/tasks/office-api-path-prefix-update.md
@@ -34,10 +34,10 @@ Goal: Change frontend and gateway paths for Office APIs to include an "office" s
   - [x] `cd frontend && npm run lint && npx tsc --noEmit && npm test`
 
 ### Documentation updates (optional but recommended)
-- [ ] Update any docs/specs mentioning the old paths to include `/api/v1/office/...`:
-  - [ ] `documentation/microsoft-email-threading-implementation.md`
-  - [ ] `tasks/api-versioning-v1.md` (service mapping examples)
-  - [ ] Any other docs referencing `/api/v1/(email|calendar|contacts)`
+- [x] Update any docs/specs mentioning the old paths to include `/api/v1/office/...`:
+  - [x] `documentation/microsoft-email-threading-implementation.md`
+  - [x] `tasks/api-versioning-v1.md` (service mapping examples)
+  - [x] Any other docs referencing `/api/v1/(email|calendar|contacts)`
 
 ### Validation
 - [ ] Local verification of gateway routing:

--- a/tasks/office-api-path-prefix-update.md
+++ b/tasks/office-api-path-prefix-update.md
@@ -40,13 +40,13 @@ Goal: Change frontend and gateway paths for Office APIs to include an "office" s
   - [x] Any other docs referencing `/api/v1/(email|calendar|contacts)`
 
 ### Validation
-- [ ] Local verification of gateway routing:
-  - [ ] `GET /api/v1/office/calendar/events` routes to Office service `/v1/calendar/events`
-  - [ ] `GET /api/v1/office/email/threads` routes to Office service `/v1/email/threads`
-  - [ ] `GET /api/v1/office/contacts` routes to Office service `/v1/contacts`
-- [ ] Manual smoke test from the app UI paths that exercise calendar, email, and contacts features
-- [ ] Confirm required headers are still proxied (auth, API keys)
-- [ ] If legacy routes retained: confirm both old and new paths work during the deprecation window
+- [x] Local verification of gateway routing:
+  - [x] `GET /api/v1/office/calendar/events` routes to Office service `/v1/calendar/events`
+  - [x] `GET /api/v1/office/email/threads` routes to Office service `/v1/email/threads`
+  - [x] `GET /api/v1/office/contacts` routes to Office service `/v1/contacts`
+- [x] Manual smoke test from the app UI paths that exercise calendar, email, and contacts features
+- [x] Confirm required headers are still proxied (auth, API keys)
+- [x] If legacy routes retained: confirm both old and new paths work during the deprecation window
 
 ### No Backwards compatibility
 - [ ] Remove legacy routes:
@@ -54,8 +54,8 @@ Goal: Change frontend and gateway paths for Office APIs to include an "office" s
   - [ ] Remove deprecation logs
 
 ### Acceptance criteria
-- [ ] Frontend only uses `/api/v1/office/(email|calendar|contacts)`
-- [ ] Gateway proxies the new routes correctly to `/v1/(email|calendar|contacts)`
-- [ ] No regressions in Office features (email, calendar, contacts) verified via UI and API
-- [ ] Documentation reflects new paths
+- [x] Frontend only uses `/api/v1/office/(email|calendar|contacts)`
+- [x] Gateway proxies the new routes correctly to `/v1/(email|calendar|contacts)`
+- [x] No regressions in Office features (email, calendar, contacts) verified via UI and API
+- [x] Documentation reflects new paths
 

--- a/tasks/office-api-path-prefix-update.md
+++ b/tasks/office-api-path-prefix-update.md
@@ -1,0 +1,66 @@
+## Office API path prefix update: add "office" segment
+
+Goal: Change frontend and gateway paths for Office APIs to include an "office" segment, e.g. `/api/v1/office/email` instead of `/api/v1/email` (likewise for calendar and contacts). Backend Office service routing remains unchanged (`/v1/email`, `/v1/calendar`, `/v1/contacts`).
+
+### Scope
+- Affects only gateway route definitions and frontend API client calls for Office endpoints
+- Endpoints in scope: email, calendar, contacts
+- Backend Office service stays the same; gateway pathRewrite handles the mapping
+
+### Gateway changes
+- [ ] Add new service route keys in `gateway/express_gateway.tsx` `serviceRoutes` for:
+  - [ ] `/api/v1/office/email` → `OFFICE_SERVICE_URL`
+  - [ ] `/api/v1/office/calendar` → `OFFICE_SERVICE_URL`
+  - [ ] `/api/v1/office/contacts` → `OFFICE_SERVICE_URL`
+- [ ] Add proxy `app.use` handlers for the new routes with path rewrites:
+  - [ ] `/api/v1/office/email` and `/api/v1/office/email/*` → rewrite `^/api/v1/office/email` → `/v1/email`
+  - [ ] `/api/v1/office/calendar` and `/api/v1/office/calendar/*` → rewrite `^/api/v1/office/calendar` → `/v1/calendar`
+  - [ ] `/api/v1/office/contacts` and `/api/v1/office/contacts/*` → rewrite `^/api/v1/office/contacts` → `/v1/contacts`
+- [ ] Update WebSocket upgrade routing to recognize new paths (grouped with Office service):
+  - [ ] Replace checks for `/api/v1/(calendar|email|contacts)` with `/api/v1/office/(calendar|email|contacts)`
+  - [ ] Keep legacy checks temporarily if enabling a deprecation window
+- [ ] Update gateway startup logging to print the new routes; optionally mark legacy routes as deprecated
+- [ ] Decide on backward compatibility policy:
+  - [ ] Option A: Keep legacy routes (`/api/v1/email|calendar|contacts`) active for N weeks with deprecation warnings
+  - [ ] Option B: Remove legacy routes immediately (breaking change)
+
+### Frontend changes
+- [ ] Update `frontend/api/clients/office-client.ts` to use the new prefixed paths:
+  - [ ] Calendar: replace `/api/v1/calendar/...` → `/api/v1/office/calendar/...`
+  - [ ] Email: replace `/api/v1/email/...` → `/api/v1/office/email/...`
+  - [ ] Contacts: replace `/api/v1/contacts...` → `/api/v1/office/contacts...`
+- [ ] Search the frontend for any additional hard-coded Office API paths and update if found
+  - [ ] Grep: `/api/v1/(email|calendar|contacts)` across `frontend/`
+- [ ] Run frontend type-check and tests
+  - [ ] `cd frontend && npm run lint && npx tsc --noEmit && npm test`
+
+### Documentation updates (optional but recommended)
+- [ ] Update any docs/specs mentioning the old paths to include `/api/v1/office/...`:
+  - [ ] `documentation/microsoft-email-threading-implementation.md`
+  - [ ] `tasks/api-versioning-v1.md` (service mapping examples)
+  - [ ] Any other docs referencing `/api/v1/(email|calendar|contacts)`
+
+### Validation
+- [ ] Local verification of gateway routing:
+  - [ ] `GET /api/v1/office/calendar/events` routes to Office service `/v1/calendar/events`
+  - [ ] `GET /api/v1/office/email/threads` routes to Office service `/v1/email/threads`
+  - [ ] `GET /api/v1/office/contacts` routes to Office service `/v1/contacts`
+- [ ] Manual smoke test from the app UI paths that exercise calendar, email, and contacts features
+- [ ] Confirm required headers are still proxied (auth, API keys)
+- [ ] If legacy routes retained: confirm both old and new paths work during the deprecation window
+
+### Rollout/Backwards compatibility
+- [ ] If using a deprecation window:
+  - [ ] Keep legacy routes active in gateway
+  - [ ] Add warning logs on legacy route access
+  - [ ] Communicate deprecation and removal timeline
+- [ ] Remove legacy routes after the window:
+  - [ ] Delete old `/api/v1/(email|calendar|contacts)` handlers and route keys in the gateway
+  - [ ] Remove deprecation logs
+
+### Acceptance criteria
+- [ ] Frontend only uses `/api/v1/office/(email|calendar|contacts)`
+- [ ] Gateway proxies the new routes correctly to `/v1/(email|calendar|contacts)`
+- [ ] No regressions in Office features (email, calendar, contacts) verified via UI and API
+- [ ] Documentation reflects new paths
+

--- a/tasks/office-api-path-prefix-update.md
+++ b/tasks/office-api-path-prefix-update.md
@@ -8,21 +8,20 @@ Goal: Change frontend and gateway paths for Office APIs to include an "office" s
 - Backend Office service stays the same; gateway pathRewrite handles the mapping
 
 ### Gateway changes
-- [ ] Add new service route keys in `gateway/express_gateway.tsx` `serviceRoutes` for:
-  - [ ] `/api/v1/office/email` → `OFFICE_SERVICE_URL`
-  - [ ] `/api/v1/office/calendar` → `OFFICE_SERVICE_URL`
-  - [ ] `/api/v1/office/contacts` → `OFFICE_SERVICE_URL`
-- [ ] Add proxy `app.use` handlers for the new routes with path rewrites:
-  - [ ] `/api/v1/office/email` and `/api/v1/office/email/*` → rewrite `^/api/v1/office/email` → `/v1/email`
-  - [ ] `/api/v1/office/calendar` and `/api/v1/office/calendar/*` → rewrite `^/api/v1/office/calendar` → `/v1/calendar`
-  - [ ] `/api/v1/office/contacts` and `/api/v1/office/contacts/*` → rewrite `^/api/v1/office/contacts` → `/v1/contacts`
-- [ ] Update WebSocket upgrade routing to recognize new paths (grouped with Office service):
-  - [ ] Replace checks for `/api/v1/(calendar|email|contacts)` with `/api/v1/office/(calendar|email|contacts)`
-  - [ ] Keep legacy checks temporarily if enabling a deprecation window
-- [ ] Update gateway startup logging to print the new routes; optionally mark legacy routes as deprecated
-- [ ] Decide on backward compatibility policy:
-  - [ ] Option A: Keep legacy routes (`/api/v1/email|calendar|contacts`) active for N weeks with deprecation warnings
-  - [ ] Option B: Remove legacy routes immediately (breaking change)
+- [x] Add new service route keys in `gateway/express_gateway.tsx` `serviceRoutes` for:
+  - [x] `/api/v1/office/email` → `OFFICE_SERVICE_URL`
+  - [x] `/api/v1/office/calendar` → `OFFICE_SERVICE_URL`
+  - [x] `/api/v1/office/contacts` → `OFFICE_SERVICE_URL`
+- [x] Add proxy `app.use` handlers for the new routes with path rewrites:
+  - [x] `/api/v1/office/email` and `/api/v1/office/email/*` → rewrite `^/api/v1/office/email` → `/v1/email`
+  - [x] `/api/v1/office/calendar` and `/api/v1/office/calendar/*` → rewrite `^/api/v1/office/calendar` → `/v1/calendar`
+  - [x] `/api/v1/office/contacts` and `/api/v1/office/contacts/*` → rewrite `^/api/v1/office/contacts` → `/v1/contacts`
+- [x] Update WebSocket upgrade routing to recognize new paths (grouped with Office service):
+  - [x] Replace checks for `/api/v1/(calendar|email|contacts)` with `/api/v1/office/(calendar|email|contacts)`
+  - [x] Keep legacy checks temporarily if enabling a deprecation window
+- [x] Update gateway startup logging to print the new routes; optionally mark legacy routes as deprecated
+- [x] Decide on backward compatibility policy:
+  - [x] Option A: Keep legacy routes (`/api/v1/email|calendar|contacts`) active for N weeks with deprecation warnings
 
 ### Frontend changes
 - [ ] Update `frontend/api/clients/office-client.ts` to use the new prefixed paths:

--- a/tasks/office-api-path-prefix-update.md
+++ b/tasks/office-api-path-prefix-update.md
@@ -24,14 +24,14 @@ Goal: Change frontend and gateway paths for Office APIs to include an "office" s
   - [x] Option A: Keep legacy routes (`/api/v1/email|calendar|contacts`) active for N weeks with deprecation warnings
 
 ### Frontend changes
-- [ ] Update `frontend/api/clients/office-client.ts` to use the new prefixed paths:
-  - [ ] Calendar: replace `/api/v1/calendar/...` → `/api/v1/office/calendar/...`
-  - [ ] Email: replace `/api/v1/email/...` → `/api/v1/office/email/...`
-  - [ ] Contacts: replace `/api/v1/contacts...` → `/api/v1/office/contacts...`
-- [ ] Search the frontend for any additional hard-coded Office API paths and update if found
-  - [ ] Grep: `/api/v1/(email|calendar|contacts)` across `frontend/`
-- [ ] Run frontend type-check and tests
-  - [ ] `cd frontend && npm run lint && npx tsc --noEmit && npm test`
+- [x] Update `frontend/api/clients/office-client.ts` to use the new prefixed paths:
+  - [x] Calendar: replace `/api/v1/calendar/...` → `/api/v1/office/calendar/...`
+  - [x] Email: replace `/api/v1/email/...` → `/api/v1/office/email/...`
+  - [x] Contacts: replace `/api/v1/contacts...` → `/api/v1/office/contacts...`
+- [x] Search the frontend for any additional hard-coded Office API paths and update if found
+  - [x] Grep: `/api/v1/(email|calendar|contacts)` across `frontend/`
+- [x] Run frontend type-check and tests
+  - [x] `cd frontend && npm run lint && npx tsc --noEmit && npm test`
 
 ### Documentation updates (optional but recommended)
 - [ ] Update any docs/specs mentioning the old paths to include `/api/v1/office/...`:
@@ -48,12 +48,8 @@ Goal: Change frontend and gateway paths for Office APIs to include an "office" s
 - [ ] Confirm required headers are still proxied (auth, API keys)
 - [ ] If legacy routes retained: confirm both old and new paths work during the deprecation window
 
-### Rollout/Backwards compatibility
-- [ ] If using a deprecation window:
-  - [ ] Keep legacy routes active in gateway
-  - [ ] Add warning logs on legacy route access
-  - [ ] Communicate deprecation and removal timeline
-- [ ] Remove legacy routes after the window:
+### No Backwards compatibility
+- [ ] Remove legacy routes:
   - [ ] Delete old `/api/v1/(email|calendar|contacts)` handlers and route keys in the gateway
   - [ ] Remove deprecation logs
 


### PR DESCRIPTION
This separates office service contacts (direct from provider) vs. our discovered contacts service