### PR TITLE
feat(gateway): route contacts to dedicated Contacts Service

### DIFF
--- a/gateway/express_gateway.tsx
+++ b/gateway/express_gateway.tsx
@@ -441,19 +441,14 @@ if (process.env.NODE_ENV !== 'production') {
 const serviceRoutes = {
     '/api/v1/users': process.env.USER_SERVICE_URL || 'http://127.0.0.1:8001',
     '/api/v1/chat': process.env.CHAT_SERVICE_URL || 'http://127.0.0.1:8002',
-    '/api/v1/calendar': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
-    '/api/v1/email': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
-    '/api/v1/files': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
-    '/api/v1/contacts': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
-    '/api/v1/office/calendar': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
-    '/api/v1/office/email': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
-    '/api/v1/office/contacts': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
+    '/api/v1/office': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8003',
     '/api/v1/drafts': process.env.CHAT_SERVICE_URL || 'http://127.0.0.1:8002',
     '/api/v1/shipments': process.env.SHIPMENTS_SERVICE_URL || 'http://127.0.0.1:8004',
     '/api/v1/meetings': process.env.MEETINGS_SERVICE_URL || 'http://127.0.0.1:8005',
     '/api/v1/bookings': process.env.MEETINGS_SERVICE_URL || 'http://127.0.0.1:8005',
     '/api/v1/public/polls': process.env.MEETINGS_SERVICE_URL || 'http://127.0.0.1:8005',
     '/api/v1/search': process.env.VESPA_QUERY_URL || 'http://127.0.0.1:8006',
+    '/api/v1/contacts': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8007',
 };
 
 // Create proxy middleware factory
@@ -515,6 +510,10 @@ const createServiceProxy = (targetUrl: string, pathRewrite?: Record<string, stri
                 // Vespa query service
                 proxyReq.setHeader('X-API-Key', process.env.API_FRONTEND_VESPA_QUERY_KEY || '');
                 logger.debug(`Setting API key for vespa query service: ${process.env.API_FRONTEND_VESPA_QUERY_KEY ? 'present' : 'missing'}`);
+            } else if (targetUrl.includes('8007')) {
+                // Contacts service
+                proxyReq.setHeader('X-API-Key', process.env.API_FRONTEND_CONTACTS_KEY || '');
+                logger.debug(`Setting API key for contacts service: ${process.env.API_FRONTEND_CONTACTS_KEY ? 'present' : 'missing'}`);
             } else {
                 logger.warn(`No API key assigned for target URL: ${targetUrl}`);
             }
@@ -608,12 +607,7 @@ app.use('/api/v1/users', validateAuth, standardLimiter, createServiceProxy(servi
 app.use('/api/v1/users/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/users'], { '^/api/v1/users': '/v1/users' }));
 app.use('/api/v1/chat', validateAuth, strictLimiter, createServiceProxy(serviceRoutes['/api/v1/chat'], { '^/api/v1/chat': '/v1/chat' }));
 app.use('/api/v1/chat/*', validateAuth, strictLimiter, createServiceProxy(serviceRoutes['/api/v1/chat'], { '^/api/v1/chat': '/v1/chat' }));
-app.use('/api/v1/calendar', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/calendar'], { '^/api/v1/calendar': '/v1/calendar' }));
-app.use('/api/v1/calendar/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/calendar'], { '^/api/v1/calendar': '/v1/calendar' }));
-app.use('/api/v1/email', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/email'], { '^/api/v1/email': '/v1/email' }));
-app.use('/api/v1/email/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/email'], { '^/api/v1/email': '/v1/email' }));
-app.use('/api/v1/files', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/files'], { '^/api/v1/files': '/v1/files' }));
-app.use('/api/v1/files/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/files'], { '^/api/v1/files': '/v1/files' }));
+app.use('/api/v1/office', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office'], { '^/api/v1/office': '/v1/' }));
 app.use('/api/v1/drafts', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/drafts'], { '^/api/v1/drafts': '/v1/chat/drafts' }));
 app.use('/api/v1/drafts/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/drafts'], { '^/api/v1/drafts': '/v1/chat/drafts' }));
 app.use('/api/v1/meetings', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/meetings'], { '^/api/v1/meetings': '/api/v1/meetings' }));
@@ -626,14 +620,6 @@ app.use('/api/v1/shipments', validateAuth, standardLimiter, createServiceProxy(s
 app.use('/api/v1/shipments/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/shipments'], { '^/api/v1/shipments': '/v1/shipments' }));
 app.use('/api/v1/contacts', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/contacts'], { '^/api/v1/contacts': '/v1/contacts/' }));
 app.use('/api/v1/contacts/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/contacts'], { '^/api/v1/contacts': '/v1/contacts' }));
-
-// New office-prefixed routes
-app.use('/api/v1/office/calendar', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office/calendar'], { '^/api/v1/office/calendar': '/v1/calendar' }));
-app.use('/api/v1/office/calendar/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office/calendar'], { '^/api/v1/office/calendar': '/v1/calendar' }));
-app.use('/api/v1/office/email', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office/email'], { '^/api/v1/office/email': '/v1/email' }));
-app.use('/api/v1/office/email/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office/email'], { '^/api/v1/office/email': '/v1/email' }));
-app.use('/api/v1/office/contacts', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office/contacts'], { '^/api/v1/office/contacts': '/v1/contacts' }));
-app.use('/api/v1/office/contacts/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office/contacts'], { '^/api/v1/office/contacts': '/v1/contacts' }));
 
 // Catch-all for undefined routes
 app.use('*', (req, res) => {
@@ -660,21 +646,15 @@ const server = app.listen(PORT, () => {
     logWithContext('info', `Auth proxy running on port ${PORT}`);
     logWithContext('info', `Frontend URL: ${process.env.FRONTEND_URL || 'http://localhost:3000'}`);
     logWithContext('info', `Environment: ${process.env.NODE_ENV || 'development'}`);
-    logWithContext('info', 'Service Routing:');
-    logWithContext('info', `  /api/v1/users    → ${serviceRoutes['/api/v1/users']}`);
-    logWithContext('info', `  /api/v1/chat     → ${serviceRoutes['/api/v1/chat']}`);
-    logWithContext('info', `  /api/v1/calendar → ${serviceRoutes['/api/v1/calendar']}`);
-    logWithContext('info', `  /api/v1/email    → ${serviceRoutes['/api/v1/email']}`);
-    logWithContext('info', `  /api/v1/files    → ${serviceRoutes['/api/v1/files']}`);
-    logWithContext('info', `  /api/v1/contacts → ${serviceRoutes['/api/v1/contacts']}`);
-    logWithContext('info', `  /api/v1/office/calendar → ${serviceRoutes['/api/v1/office/calendar']}`);
-    logWithContext('info', `  /api/v1/office/email → ${serviceRoutes['/api/v1/office/email']}`);
-    logWithContext('info', `  /api/v1/office/contacts → ${serviceRoutes['/api/v1/office/contacts']}`);
-    logWithContext('info', `  /api/v1/drafts     → ${serviceRoutes['/api/v1/drafts']}`);
-    logWithContext('info', `  /api/v1/meetings → ${serviceRoutes['/api/v1/meetings']}`);
-    logWithContext('info', `  /api/v1/bookings → ${serviceRoutes['/api/v1/bookings']}`);
+    logWithContext('info', `  /api/v1/users        → ${serviceRoutes['/api/v1/users']}`);
+    logWithContext('info', `  /api/v1/chat         → ${serviceRoutes['/api/v1/chat']}`);
+    logWithContext('info', `  /api/v1/office       → ${serviceRoutes['/api/v1/office']}`);
+    logWithContext('info', `  /api/v1/contacts     → ${serviceRoutes['/api/v1/contacts']}`);
+    logWithContext('info', `  /api/v1/drafts       → ${serviceRoutes['/api/v1/drafts']}`);
+    logWithContext('info', `  /api/v1/meetings     → ${serviceRoutes['/api/v1/meetings']}`);
+    logWithContext('info', `  /api/v1/bookings     → ${serviceRoutes['/api/v1/bookings']}`);
     logWithContext('info', `  /api/v1/public/polls → ${serviceRoutes['/api/v1/public/polls']}`);
-    logWithContext('info', `  /api/v1/shipments → ${serviceRoutes['/api/v1/shipments']}`);
+    logWithContext('info', `  /api/v1/shipments    → ${serviceRoutes['/api/v1/shipments']}`);
 });
 
 // Handle WebSocket upgrades
@@ -685,12 +665,16 @@ server.on('upgrade', (request: any, socket: any, head: any) => {
     const url = new URL(request.url || '', `http://${request.headers.host}`);
     const path = url.pathname;
 
-    let targetService = serviceRoutes['/api/v1/users']; // Default to user service
+    let targetService = null;
 
     if (path.startsWith('/api/v1/chat')) {
         targetService = serviceRoutes['/api/v1/chat'];
-    } else if (path.startsWith('/api/v1/office/calendar') || path.startsWith('/api/v1/office/email') || path.startsWith('/api/v1/office/contacts') || path.startsWith('/api/v1/calendar') || path.startsWith('/api/v1/email') || path.startsWith('/api/v1/files') || path.startsWith('/api/v1/contacts')) {
-        targetService = serviceRoutes['/api/v1/calendar'];
+    } else if (path.startsWith('/api/v1/users')) {
+        targetService = serviceRoutes['/api/v1/users'];
+    } else if (path.startsWith('/api/v1/office')) {
+        targetService = serviceRoutes['/api/v1/office'];
+    } else if (path.startsWith('/api/v1/contacts')) {
+        targetService = serviceRoutes['/api/v1/contacts'];
     } else if (path.startsWith('/api/v1/meetings')) {
         targetService = serviceRoutes['/api/v1/meetings'];
     } else if (path.startsWith('/api/v1/bookings')) {
@@ -699,6 +683,12 @@ server.on('upgrade', (request: any, socket: any, head: any) => {
         targetService = serviceRoutes['/api/v1/public/polls'];
     } else if (path.startsWith('/api/v1/shipments')) {
         targetService = serviceRoutes['/api/v1/shipments'];
+    } else {
+        logWithContext('error', 'Unknown WebSocket path', {
+            path,
+            targetService
+        });
+        return;
     }
 
     // Create proxy for WebSocket

--- a/gateway/express_gateway.tsx
+++ b/gateway/express_gateway.tsx
@@ -619,7 +619,7 @@ app.use('/api/v1/public/polls', standardLimiter, createServiceProxy(serviceRoute
 app.use('/api/v1/public/polls/*', standardLimiter, createServiceProxy(serviceRoutes['/api/v1/public/polls'], { '^/api/v1/public/polls': '/api/v1/public/polls' }));
 app.use('/api/v1/shipments', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/shipments'], { '^/api/v1/shipments': '/v1/shipments' }));
 app.use('/api/v1/shipments/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/shipments'], { '^/api/v1/shipments': '/v1/shipments' }));
-app.use('/api/v1/contacts', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/contacts'], { '^/api/v1/contacts': '/v1/contacts/' }));
+app.use('/api/v1/contacts', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/contacts'], { '^/api/v1/contacts': '/v1/contacts' }));
 app.use('/api/v1/contacts/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/contacts'], { '^/api/v1/contacts': '/v1/contacts' }));
 
 // Catch-all for undefined routes

--- a/gateway/express_gateway.tsx
+++ b/gateway/express_gateway.tsx
@@ -448,7 +448,7 @@ const serviceRoutes = {
     '/api/v1/bookings': process.env.MEETINGS_SERVICE_URL || 'http://127.0.0.1:8005',
     '/api/v1/public/polls': process.env.MEETINGS_SERVICE_URL || 'http://127.0.0.1:8005',
     '/api/v1/search': process.env.VESPA_QUERY_URL || 'http://127.0.0.1:8006',
-    '/api/v1/contacts': process.env.OFFICE_SERVICE_URL || 'http://127.0.0.1:8007',
+    '/api/v1/contacts': process.env.CONTACTS_SERVICE_URL || 'http://127.0.0.1:8007',
 };
 
 // Create proxy middleware factory

--- a/gateway/express_gateway.tsx
+++ b/gateway/express_gateway.tsx
@@ -608,6 +608,7 @@ app.use('/api/v1/users/*', validateAuth, standardLimiter, createServiceProxy(ser
 app.use('/api/v1/chat', validateAuth, strictLimiter, createServiceProxy(serviceRoutes['/api/v1/chat'], { '^/api/v1/chat': '/v1/chat' }));
 app.use('/api/v1/chat/*', validateAuth, strictLimiter, createServiceProxy(serviceRoutes['/api/v1/chat'], { '^/api/v1/chat': '/v1/chat' }));
 app.use('/api/v1/office', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office'], { '^/api/v1/office': '/v1/' }));
+app.use('/api/v1/office/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/office'], { '^/api/v1/office': '/v1/' }));
 app.use('/api/v1/drafts', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/drafts'], { '^/api/v1/drafts': '/v1/chat/drafts' }));
 app.use('/api/v1/drafts/*', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/drafts'], { '^/api/v1/drafts': '/v1/chat/drafts' }));
 app.use('/api/v1/meetings', validateAuth, standardLimiter, createServiceProxy(serviceRoutes['/api/v1/meetings'], { '^/api/v1/meetings': '/api/v1/meetings' }));


### PR DESCRIPTION
- Add API key authentication for Contacts Service
- Separate WebSocket routing for contacts from office service
- Maintain existing proxy path rewriting (/api/v1/office/contacts -> /v1/contacts/)