### PR TITLE
test: Add tmp-pg for testing, restore JSONB fields to contacts

### DIFF
--- a/documentation/user-management-service.md
+++ b/documentation/user-management-service.md
@@ -183,12 +183,14 @@ class BaseMeta(sqlmodel.SQLModel): # TODO: Check if this is the correct base cla
 class IntegrationProvider(str, Enum):
     GOOGLE = "google"
     MICROSOFT = "microsoft"
+    SLACK = "slack"
 
 class IntegrationStatus(str, Enum):
-    CONNECTED = "connected"
-    EXPIRED = "expired"
-    REVOKED = "revoked"
-    ERROR = "error"
+    ACTIVE = "ACTIVE"      # Connected and working
+    INACTIVE = "INACTIVE"  # Disconnected by user
+    ERROR = "ERROR"        # Connection error or expired tokens
+    PENDING = "PENDING"    # OAuth flow in progress
+    EXPIRED = "EXPIRED"    # Token was valid but is now expired
 
 class User(sqlmodel.SQLModel, table=True):
     __tablename__ = "users"
@@ -246,7 +248,7 @@ class Integration(sqlmodel.SQLModel, table=True):
     id: str = sqlmodel.Field(default_factory=sqlmodel.uuid4, primary_key=True)
     user_id: str = sqlmodel.Field(default=None, foreign_key="users.id") # TODO: Check ondelete="CASCADE"
     provider: IntegrationProvider = sqlmodel.Field(default=None, max_length=50)
-    status: IntegrationStatus = sqlmodel.Field(default=IntegrationStatus.CONNECTED, max_length=20)
+    status: IntegrationStatus = sqlmodel.Field(default=IntegrationStatus.ACTIVE, max_length=20)
     connected_at: datetime = sqlmodel.Field(default_factory=datetime.utcnow)
     last_refresh_at: Optional[datetime] = sqlmodel.Field(default=None)
     expires_at: Optional[datetime] = sqlmodel.Field(default=None)

--- a/services/contacts/models/contact.py
+++ b/services/contacts/models/contact.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import JSON, Column, DateTime, Text, func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
 
 
@@ -50,7 +51,7 @@ class Contact(SQLModel, table=True):
     # Event tracking - stored as JSONB in PostgreSQL
     event_counts: Dict[str, EmailContactEventCount] = Field(
         default_factory=dict,
-        sa_column=Column(JSON),
+        sa_column=Column(JSONB),
         description="Count of events by type for this contact",
     )
     total_event_count: int = Field(
@@ -73,18 +74,18 @@ class Contact(SQLModel, table=True):
     )
     relevance_factors: Dict[str, float] = Field(
         default_factory=dict,
-        sa_column=Column(JSON),
+        sa_column=Column(JSONB),
         description="Factors contributing to relevance score",
     )
 
     # Metadata
     source_services: List[str] = Field(
         default_factory=list,
-        sa_column=Column(JSON),
+        sa_column=Column(JSONB),
         description="Services where this contact was discovered",
     )
     tags: List[str] = Field(
-        default_factory=list, sa_column=Column(JSON), description="Contact tags"
+        default_factory=list, sa_column=Column(JSONB), description="Contact tags"
     )
     notes: Optional[str] = Field(
         default=None, description="Additional notes about the contact"
@@ -101,12 +102,12 @@ class Contact(SQLModel, table=True):
     )
     phone_numbers: List[str] = Field(
         default_factory=list,
-        sa_column=Column(JSON),
+        sa_column=Column(JSONB),
         description="Contact phone numbers",
     )
     addresses: List[Dict[str, Any]] = Field(
         default_factory=list,
-        sa_column=Column(JSON),
+        sa_column=Column(JSONB),
         description="Contact addresses",
     )
 

--- a/services/contacts/pyproject.toml
+++ b/services/contacts/pyproject.toml
@@ -27,6 +27,7 @@ test = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "httpx>=0.25.0,<1.0.0",
+    "testcontainers>=4.12.0",
 ]
 
 [build-system]
@@ -36,3 +37,8 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["*"]
+
+[dependency-groups]
+dev = [
+    "testcontainers[postgresql]>=4.12.0",
+]

--- a/services/contacts/pyproject.toml
+++ b/services/contacts/pyproject.toml
@@ -37,8 +37,3 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["*"]
-
-[dependency-groups]
-dev = [
-    "testcontainers[postgresql]>=4.12.0",
-]

--- a/services/contacts/tests/test_jsonb_integration.py
+++ b/services/contacts/tests/test_jsonb_integration.py
@@ -156,39 +156,47 @@ def test_jsonb_field_validation():
         addresses=[],
     )
     
-    # Test nested dictionaries
-    # Test that event_counts can store EmailContactEventCount objects with complex metadata
+    # Test nested dictionaries with proper EmailContactEventCount objects
     contact.event_counts = {
-        "complex_email_event": EmailContactEventCount(
-            event_type="complex_email_event",
+        "complex": EmailContactEventCount(
+            event_type="complex",
             count=42,
             last_seen=datetime.now(timezone.utc),
             first_seen=datetime.now(timezone.utc),
-            # If EmailContactEventCount supports additional metadata,
-            # it should be added as proper fields rather than arbitrary nested data
+        ),
+        "nested": EmailContactEventCount(
+            event_type="nested",
+            count=10,
+            last_seen=datetime.now(timezone.utc),
+            first_seen=datetime.now(timezone.utc),
+        ),
+        "deep": EmailContactEventCount(
+            event_type="deep",
+            count=5,
+            last_seen=datetime.now(timezone.utc),
+            first_seen=datetime.now(timezone.utc),
         )
     }
     
-    # Test mixed data types
+    # Test mixed data types for relevance_factors (should be numeric)
     contact.relevance_factors = {
-        "string": "value",
-        "number": 3.14,
-        "boolean": False,
-        "null": None,
-        "array": ["a", "b", "c"],
-        "object": {"key": "value"}
+        "recency": 0.8,
+        "frequency": 0.6,
+        "diversity": 0.4,
+        "complexity": 0.9,
+        "engagement": 0.7
     }
     
     # Verify complex data is stored correctly
-    assert contact.event_counts["complex"]["nested"]["deep"]["value"] == 42
-    assert contact.event_counts["complex"]["nested"]["deep"]["text"] == "deeply nested"
-    assert contact.event_counts["complex"]["nested"]["deep"]["boolean"] is True
-    assert contact.event_counts["complex"]["nested"]["deep"]["null"] is None
-    assert contact.event_counts["complex"]["nested"]["deep"]["array"] == [1, 2, 3]
+    assert contact.event_counts["complex"].event_type == "complex"
+    assert contact.event_counts["complex"].count == 42
+    assert contact.event_counts["nested"].event_type == "nested"
+    assert contact.event_counts["nested"].count == 10
+    assert contact.event_counts["deep"].event_type == "deep"
+    assert contact.event_counts["deep"].count == 5
     
-    assert contact.relevance_factors["string"] == "value"
-    assert contact.relevance_factors["number"] == 3.14
-    assert contact.relevance_factors["boolean"] is False
-    assert contact.relevance_factors["null"] is None
-    assert contact.relevance_factors["array"] == ["a", "b", "c"]
-    assert contact.relevance_factors["object"] == {"key": "value"}
+    assert contact.relevance_factors["recency"] == 0.8
+    assert contact.relevance_factors["frequency"] == 0.6
+    assert contact.relevance_factors["diversity"] == 0.4
+    assert contact.relevance_factors["complexity"] == 0.9
+    assert contact.relevance_factors["engagement"] == 0.7

--- a/services/contacts/tests/test_jsonb_integration.py
+++ b/services/contacts/tests/test_jsonb_integration.py
@@ -5,8 +5,9 @@ This is a prototype test that demonstrates how JSONB fields would work
 with PostgreSQL, without requiring actual database connectivity.
 """
 
-import pytest
 from datetime import datetime, timezone
+
+import pytest
 
 from services.contacts.models.contact import Contact, EmailContactEventCount
 
@@ -37,57 +38,57 @@ def test_jsonb_field_types() -> None:
                 "street": "123 Main St",
                 "city": "Test City",
                 "state": "TS",
-                "zip": "12345"
+                "zip": "12345",
             },
             {
                 "type": "work",
                 "street": "456 Business Ave",
                 "city": "Work City",
                 "state": "WC",
-                "zip": "67890"
-            }
+                "zip": "67890",
+            },
         ],
     )
-    
+
     # Verify JSONB fields can store complex nested data
     assert isinstance(contact.event_counts, dict)
     assert "email" in contact.event_counts
     assert isinstance(contact.event_counts["email"], EmailContactEventCount)
     assert contact.event_counts["email"].event_type == "email"
     assert contact.event_counts["email"].count == 5
-    
+
     # Verify relevance factors
     assert isinstance(contact.relevance_factors, dict)
     assert contact.relevance_factors["recency"] == 0.8
     assert contact.relevance_factors["frequency"] == 0.6
     assert contact.relevance_factors["diversity"] == 0.4
-    
+
     # Verify source services
     assert isinstance(contact.source_services, list)
     assert "email" in contact.source_services
     assert "calendar" in contact.source_services
     assert "documents" in contact.source_services
-    
+
     # Verify tags
     assert isinstance(contact.tags, list)
     assert "important" in contact.tags
     assert "customer" in contact.tags
     assert "vip" in contact.tags
-    
+
     # Verify phone numbers
     assert isinstance(contact.phone_numbers, list)
     assert "+1234567890" in contact.phone_numbers
     assert "+0987654321" in contact.phone_numbers
-    
+
     # Verify addresses
     assert isinstance(contact.addresses, list)
     assert len(contact.addresses) == 2
-    
+
     home_address = contact.addresses[0]
     assert home_address["type"] == "home"
     assert home_address["street"] == "123 Main St"
     assert home_address["city"] == "Test City"
-    
+
     work_address = contact.addresses[1]
     assert work_address["type"] == "work"
     assert work_address["street"] == "456 Business Ave"
@@ -108,7 +109,7 @@ def test_jsonb_field_serialization() -> None:
         phone_numbers=[],
         addresses=[],
     )
-    
+
     # Test that empty JSONB fields work
     assert contact.event_counts == {}
     assert contact.relevance_factors == {}
@@ -116,7 +117,7 @@ def test_jsonb_field_serialization() -> None:
     assert contact.tags == []
     assert contact.phone_numbers == []
     assert contact.addresses == []
-    
+
     # Test that we can modify JSONB fields
     contact.event_counts["new_event"] = EmailContactEventCount(
         event_type="new_event",
@@ -124,13 +125,13 @@ def test_jsonb_field_serialization() -> None:
         last_seen=datetime.now(timezone.utc),
         first_seen=datetime.now(timezone.utc),
     )
-    
+
     contact.relevance_factors["new_factor"] = 0.9
     contact.source_services.append("new_service")
     contact.tags.append("new_tag")
     contact.phone_numbers.append("+1111111111")
     contact.addresses.append({"type": "new", "street": "New St"})
-    
+
     # Verify modifications
     assert "new_event" in contact.event_counts
     assert contact.relevance_factors["new_factor"] == 0.9
@@ -155,7 +156,7 @@ def test_jsonb_field_validation() -> None:
         phone_numbers=[],
         addresses=[],
     )
-    
+
     # Test nested dictionaries with proper EmailContactEventCount objects
     contact.event_counts = {
         "complex": EmailContactEventCount(
@@ -175,18 +176,18 @@ def test_jsonb_field_validation() -> None:
             count=5,
             last_seen=datetime.now(timezone.utc),
             first_seen=datetime.now(timezone.utc),
-        )
+        ),
     }
-    
+
     # Test mixed data types for relevance_factors (should be numeric)
     contact.relevance_factors = {
         "recency": 0.8,
         "frequency": 0.6,
         "diversity": 0.4,
         "complexity": 0.9,
-        "engagement": 0.7
+        "engagement": 0.7,
     }
-    
+
     # Verify complex data is stored correctly
     assert contact.event_counts["complex"].event_type == "complex"
     assert contact.event_counts["complex"].count == 42
@@ -194,7 +195,7 @@ def test_jsonb_field_validation() -> None:
     assert contact.event_counts["nested"].count == 10
     assert contact.event_counts["deep"].event_type == "deep"
     assert contact.event_counts["deep"].count == 5
-    
+
     assert contact.relevance_factors["recency"] == 0.8
     assert contact.relevance_factors["frequency"] == 0.6
     assert contact.relevance_factors["diversity"] == 0.4

--- a/services/contacts/tests/test_jsonb_integration.py
+++ b/services/contacts/tests/test_jsonb_integration.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from services.contacts.models.contact import Contact, EmailContactEventCount
 
 
-def test_jsonb_field_types():
+def test_jsonb_field_types() -> None:
     """Test that JSONB fields are properly typed and can store complex data."""
     # Create a contact with complex JSONB data
     contact = Contact(
@@ -94,7 +94,7 @@ def test_jsonb_field_types():
     assert work_address["city"] == "Work City"
 
 
-def test_jsonb_field_serialization():
+def test_jsonb_field_serialization() -> None:
     """Test that JSONB fields can be properly serialized for database storage."""
     contact = Contact(
         user_id="test_user_2",
@@ -140,7 +140,7 @@ def test_jsonb_field_serialization():
     assert any(addr["type"] == "new" for addr in contact.addresses)
 
 
-def test_jsonb_field_validation():
+def test_jsonb_field_validation() -> None:
     """Test that JSONB fields properly validate data types."""
     # Test with various data types that should work in JSONB
     contact = Contact(

--- a/services/contacts/tests/test_jsonb_integration.py
+++ b/services/contacts/tests/test_jsonb_integration.py
@@ -157,18 +157,16 @@ def test_jsonb_field_validation():
     )
     
     # Test nested dictionaries
+    # Test that event_counts can store EmailContactEventCount objects with complex metadata
     contact.event_counts = {
-        "complex": {
-            "nested": {
-                "deep": {
-                    "value": 42,
-                    "text": "deeply nested",
-                    "boolean": True,
-                    "null": None,
-                    "array": [1, 2, 3]
-                }
-            }
-        }
+        "complex_email_event": EmailContactEventCount(
+            event_type="complex_email_event",
+            count=42,
+            last_seen=datetime.now(timezone.utc),
+            first_seen=datetime.now(timezone.utc),
+            # If EmailContactEventCount supports additional metadata,
+            # it should be added as proper fields rather than arbitrary nested data
+        )
     }
     
     # Test mixed data types

--- a/services/contacts/tests/test_jsonb_integration.py
+++ b/services/contacts/tests/test_jsonb_integration.py
@@ -1,0 +1,196 @@
+"""
+Test JSONB integration concept for the contacts service.
+
+This is a prototype test that demonstrates how JSONB fields would work
+with PostgreSQL, without requiring actual database connectivity.
+"""
+
+import pytest
+from datetime import datetime, timezone
+
+from services.contacts.models.contact import Contact, EmailContactEventCount
+
+
+def test_jsonb_field_types():
+    """Test that JSONB fields are properly typed and can store complex data."""
+    # Create a contact with complex JSONB data
+    contact = Contact(
+        user_id="test_user",
+        email_address="test@example.com",
+        first_seen=datetime.now(timezone.utc),
+        last_seen=datetime.now(timezone.utc),
+        event_counts={
+            "email": EmailContactEventCount(
+                event_type="email",
+                count=5,
+                last_seen=datetime.now(timezone.utc),
+                first_seen=datetime.now(timezone.utc),
+            )
+        },
+        relevance_factors={"recency": 0.8, "frequency": 0.6, "diversity": 0.4},
+        source_services=["email", "calendar", "documents"],
+        tags=["important", "customer", "vip"],
+        phone_numbers=["+1234567890", "+0987654321"],
+        addresses=[
+            {
+                "type": "home",
+                "street": "123 Main St",
+                "city": "Test City",
+                "state": "TS",
+                "zip": "12345"
+            },
+            {
+                "type": "work",
+                "street": "456 Business Ave",
+                "city": "Work City",
+                "state": "WC",
+                "zip": "67890"
+            }
+        ],
+    )
+    
+    # Verify JSONB fields can store complex nested data
+    assert isinstance(contact.event_counts, dict)
+    assert "email" in contact.event_counts
+    assert isinstance(contact.event_counts["email"], EmailContactEventCount)
+    assert contact.event_counts["email"].event_type == "email"
+    assert contact.event_counts["email"].count == 5
+    
+    # Verify relevance factors
+    assert isinstance(contact.relevance_factors, dict)
+    assert contact.relevance_factors["recency"] == 0.8
+    assert contact.relevance_factors["frequency"] == 0.6
+    assert contact.relevance_factors["diversity"] == 0.4
+    
+    # Verify source services
+    assert isinstance(contact.source_services, list)
+    assert "email" in contact.source_services
+    assert "calendar" in contact.source_services
+    assert "documents" in contact.source_services
+    
+    # Verify tags
+    assert isinstance(contact.tags, list)
+    assert "important" in contact.tags
+    assert "customer" in contact.tags
+    assert "vip" in contact.tags
+    
+    # Verify phone numbers
+    assert isinstance(contact.phone_numbers, list)
+    assert "+1234567890" in contact.phone_numbers
+    assert "+0987654321" in contact.phone_numbers
+    
+    # Verify addresses
+    assert isinstance(contact.addresses, list)
+    assert len(contact.addresses) == 2
+    
+    home_address = contact.addresses[0]
+    assert home_address["type"] == "home"
+    assert home_address["street"] == "123 Main St"
+    assert home_address["city"] == "Test City"
+    
+    work_address = contact.addresses[1]
+    assert work_address["type"] == "work"
+    assert work_address["street"] == "456 Business Ave"
+    assert work_address["city"] == "Work City"
+
+
+def test_jsonb_field_serialization():
+    """Test that JSONB fields can be properly serialized for database storage."""
+    contact = Contact(
+        user_id="test_user_2",
+        email_address="test2@example.com",
+        first_seen=datetime.now(timezone.utc),
+        last_seen=datetime.now(timezone.utc),
+        event_counts={},
+        relevance_factors={},
+        source_services=[],
+        tags=[],
+        phone_numbers=[],
+        addresses=[],
+    )
+    
+    # Test that empty JSONB fields work
+    assert contact.event_counts == {}
+    assert contact.relevance_factors == {}
+    assert contact.source_services == []
+    assert contact.tags == []
+    assert contact.phone_numbers == []
+    assert contact.addresses == []
+    
+    # Test that we can modify JSONB fields
+    contact.event_counts["new_event"] = EmailContactEventCount(
+        event_type="new_event",
+        count=1,
+        last_seen=datetime.now(timezone.utc),
+        first_seen=datetime.now(timezone.utc),
+    )
+    
+    contact.relevance_factors["new_factor"] = 0.9
+    contact.source_services.append("new_service")
+    contact.tags.append("new_tag")
+    contact.phone_numbers.append("+1111111111")
+    contact.addresses.append({"type": "new", "street": "New St"})
+    
+    # Verify modifications
+    assert "new_event" in contact.event_counts
+    assert contact.relevance_factors["new_factor"] == 0.9
+    assert "new_service" in contact.source_services
+    assert "new_tag" in contact.tags
+    assert "+1111111111" in contact.phone_numbers
+    assert any(addr["type"] == "new" for addr in contact.addresses)
+
+
+def test_jsonb_field_validation():
+    """Test that JSONB fields properly validate data types."""
+    # Test with various data types that should work in JSONB
+    contact = Contact(
+        user_id="test_user_3",
+        email_address="test3@example.com",
+        first_seen=datetime.now(timezone.utc),
+        last_seen=datetime.now(timezone.utc),
+        event_counts={},
+        relevance_factors={},
+        source_services=[],
+        tags=[],
+        phone_numbers=[],
+        addresses=[],
+    )
+    
+    # Test nested dictionaries
+    contact.event_counts = {
+        "complex": {
+            "nested": {
+                "deep": {
+                    "value": 42,
+                    "text": "deeply nested",
+                    "boolean": True,
+                    "null": None,
+                    "array": [1, 2, 3]
+                }
+            }
+        }
+    }
+    
+    # Test mixed data types
+    contact.relevance_factors = {
+        "string": "value",
+        "number": 3.14,
+        "boolean": False,
+        "null": None,
+        "array": ["a", "b", "c"],
+        "object": {"key": "value"}
+    }
+    
+    # Verify complex data is stored correctly
+    assert contact.event_counts["complex"]["nested"]["deep"]["value"] == 42
+    assert contact.event_counts["complex"]["nested"]["deep"]["text"] == "deeply nested"
+    assert contact.event_counts["complex"]["nested"]["deep"]["boolean"] is True
+    assert contact.event_counts["complex"]["nested"]["deep"]["null"] is None
+    assert contact.event_counts["complex"]["nested"]["deep"]["array"] == [1, 2, 3]
+    
+    assert contact.relevance_factors["string"] == "value"
+    assert contact.relevance_factors["number"] == 3.14
+    assert contact.relevance_factors["boolean"] is False
+    assert contact.relevance_factors["null"] is None
+    assert contact.relevance_factors["array"] == ["a", "b", "c"]
+    assert contact.relevance_factors["object"] == {"key": "value"}

--- a/uv.lock
+++ b/uv.lock
@@ -446,6 +446,12 @@ test = [
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "testcontainers" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "testcontainers" },
 ]
 
 [package.metadata]
@@ -468,9 +474,13 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0.0" },
     { name = "sqlmodel", specifier = ">=0.0.8,<1.0.0" },
     { name = "structlog", specifier = ">=25.4.0,<26.0.0" },
+    { name = "testcontainers", extras = ["postgresql"], marker = "extra == 'test'", specifier = ">=3.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0,<1.0.0" },
 ]
 provides-extras = ["test"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "testcontainers", extras = ["postgresql"], specifier = ">=4.12.0" }]
 
 [[package]]
 name = "briefly-meetings"
@@ -1131,6 +1141,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632 },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774 },
 ]
 
 [[package]]
@@ -3037,6 +3061,16 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543 },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040 },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102 },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3478,6 +3512,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248 },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/62/01d9f648e9b943175e0dcddf749cf31c769665d8ba08df1e989427163f33/testcontainers-4.12.0.tar.gz", hash = "sha256:13ee89cae995e643f225665aad8b200b25c4f219944a6f9c0b03249ec3f31b8d", size = 66631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/e8/9e2c392e5d671afda47b917597cac8fde6a452f5776c4c9ceb93fbd2889f/testcontainers-4.12.0-py3-none-any.whl", hash = "sha256:26caef57e642d5e8c5fcc593881cf7df3ab0f0dc9170fad22765b184e226ab15", size = 111791 },
 ]
 
 [[package]]


### PR DESCRIPTION
This was a bust, but lead to good learnings:
https://gajus.com/blog/setting-up-postgre-sql-for-running-integration-tests?utm_source=chatgpt.com
https://engblog.nirvanatech.com/how-to-run-unit-tests-on-production-data-using-golang-postgresql-f2ebf38a3271
https://github.com/flyingcircusio/gocept.testdb/blob/main/src/gocept/testdb/README.rst