### PR TITLE
refactor(pydantic): migrate from Pydantic v1 to v2 patterns

### DIFF
--- a/services/api/v1/contacts/contact.py
+++ b/services/api/v1/contacts/contact.py
@@ -21,9 +21,6 @@ class EmailContactUpdate(BaseModel):
     tags: Optional[List[str]] = None
     notes: Optional[str] = None
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
-
 
 class EmailContactSearchResult(BaseModel):
     """Search result for email contacts."""
@@ -31,9 +28,6 @@ class EmailContactSearchResult(BaseModel):
     contact: Contact
     relevance_score: float
     match_highlights: List[str] = Field(default_factory=list)
-
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
 
 
 class ContactCreate(BaseModel):

--- a/services/api/v1/vespa/document_chunking.py
+++ b/services/api/v1/vespa/document_chunking.py
@@ -98,8 +98,6 @@ class DocumentChunk(BaseModel):
         description="When this chunk was last updated",
     )
 
-
-
     def to_vespa_document(self, user_id: str, provider: str) -> Dict[str, Any]:
         """Convert to Vespa document format."""
         return {

--- a/services/api/v1/vespa/document_chunking.py
+++ b/services/api/v1/vespa/document_chunking.py
@@ -98,8 +98,7 @@ class DocumentChunk(BaseModel):
         description="When this chunk was last updated",
     )
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
+
 
     def to_vespa_document(self, user_id: str, provider: str) -> Dict[str, Any]:
         """Convert to Vespa document format."""
@@ -196,9 +195,6 @@ class ChunkingRule(BaseModel):
         default=100, description="Number of chunks to process in a batch"
     )
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
-
 
 class ChunkingResult(BaseModel):
     """Result of a document chunking operation."""
@@ -240,9 +236,6 @@ class ChunkingResult(BaseModel):
         default_factory=lambda: datetime.now(timezone.utc),
         description="When chunking was completed",
     )
-
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
 
     def get_chunk_by_sequence(self, sequence: int) -> Optional[DocumentChunk]:
         """Get a chunk by its sequence number."""
@@ -401,6 +394,3 @@ class DocumentChunkingConfig(BaseModel):
     chunk_retention_days: int = Field(
         default=365, description="Days to retain chunk data"
     )
-
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}


### PR DESCRIPTION
- Remove deprecated Config classes with json_encoders
- Update to Pydantic v2 compatible patterns
- Maintain backward compatibility for datetime serialization
- Clean up unused imports and configurations